### PR TITLE
feat: add subcommands, JSON output, and test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,16 @@ yarn-error.log*
 # Cache
 .cache/
 *.tsbuildinfo
+
+# Agent configurations (local development)
+.claude/
+.codex/
+.cursor/
+.gemini/
+.goose/
+.cline/
+.mcp.json
+
+# Development tracking
+todos/
+.context/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to skillfish
+
+Thanks for your interest in contributing.
+
+## Development Setup
+
+```bash
+git clone https://github.com/YOUR_USERNAME/skillfish.git
+cd skillfish
+npm install
+npm run build
+```
+
+## Running Locally
+
+```bash
+# Link for local testing
+npm link
+
+# Run the CLI
+skillfish add owner/repo
+```
+
+## Testing
+
+```bash
+npm test           # Run tests once
+npm run test:watch # Watch mode
+```
+
+## Code Style
+
+- TypeScript with strict mode
+- ESM modules
+- Keep functions focused and testable
+
+## Pull Requests
+
+1. Fork the repo
+2. Create a feature branch
+3. Make your changes
+4. Run tests: `npm test`
+5. Run build: `npm run build`
+6. Submit a PR
+
+## Adding Agent Support
+
+To add support for a new AI agent, add an entry to `AGENT_CONFIGS` in `src/index.ts`:
+
+```typescript
+{
+  name: 'Agent Name',
+  dir: '.agent/skills',
+  homePaths: ['.agent/config.json'],  // Files in ~/
+  cwdPaths: ['.agent'],               // Files in ./
+}
+```
+
+## Reporting Issues
+
+Include:
+- Node.js version
+- Operating system
+- Steps to reproduce
+- Expected vs actual behavior
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2024-2026 Graeme Knox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,66 +9,87 @@ npx skillfish owner/repo
 ## Overview
 
 One command installs skills to **all detected agents**:
-- Claude Code (`~/.claude/skills/`)
-- Cursor (`~/.cursor/skills/`)
-- Windsurf (`~/.codeium/windsurf/skills/`)
-- Cline (`~/.cline/skills/`)
-- Codex (`~/.codex/skills/`)
-- GitHub Copilot (`~/.github/skills/`)
+
+| Agent | Skills Directory |
+|-------|------------------|
+| Claude Code | `~/.claude/skills/` |
+| Cursor | `~/.cursor/skills/` |
+| Windsurf | `~/.codeium/windsurf/skills/` |
+| Codex | `~/.codex/skills/` |
+| GitHub Copilot | `~/.github/skills/` |
+| Gemini CLI | `~/.gemini/skills/` |
+| OpenCode | `~/.opencode/skills/` |
+| Goose | `~/.goose/skills/` |
+| Amp | `~/.agents/skills/` |
+| Roo Code | `~/.roo/skills/` |
+| Kiro CLI | `~/.kiro/skills/` |
+| Kilo Code | `~/.kilocode/skills/` |
+| Trae | `~/.trae/skills/` |
+| Cline | `~/.cline/skills/` |
+| Antigravity | `~/.gemini/antigravity/skills/` |
+| Droid | `~/.factory/skills/` |
+| Clawdbot | `~/.clawdbot/skills/` |
 
 ## Usage
 
 ```bash
-# Auto-discover skill location (interactive if multiple found)
-npx skillfish owner/repo
+# Install a skill (auto-discovers SKILL.md location)
+npx skillfish add owner/repo
 
-# Full path from GitHub
-npx skillfish owner/repo/plugin/skill
+# Full path from GitHub (plugin/skill syntax)
+npx skillfish add owner/repo/plugin/skill
 
 # Specify explicit path
-npx skillfish owner/repo --path path/to/skill
+npx skillfish add owner/repo --path path/to/skill
+
+# Install all skills from a repo (non-interactive)
+npx skillfish add owner/repo --all
 
 # Overwrite existing skills
-npx skillfish owner/repo --force
+npx skillfish add owner/repo --force
+
+# Skip confirmation prompt
+npx skillfish add owner/repo --yes
+
+# List installed skills
+npx skillfish list --global
 ```
 
 ## Interactive Selection
 
-When a repo contains multiple skills, you'll get an interactive menu:
+When a repo contains multiple skills, you'll get an interactive multi-select menu with skill names and descriptions from frontmatter:
 
 ```
-Found 15 skills in this repository:
-
-  1) coding-tutor
-  2) agent-browser
-  3) agent-native-architecture
-  ...
-
-Select skill (1-15):
+◆  Select skills to install
+│  ◻ Frontend Design - Create distinctive, production-grade frontend interfaces
+│  ◻ Agent Browser - Browser automation using Vercel's agent-browser CLI
+│  ◻ Git Worktree - Manage Git worktrees for isolated parallel development
+│  ...
+└
 ```
+
+Use `--all` to install all skills non-interactively (useful for automation).
 
 ## Examples
 
 ```bash
 # Install from a skill repo with SKILL.md at root
-npx skillfish user/my-skill
+npx skillfish add user/my-skill
 
 # Install using full path from GitHub
-npx skillfish EveryInc/compound-engineering-plugin/compound-engineering/frontend-design
+npx skillfish add EveryInc/compound-engineering-plugin/compound-engineering/frontend-design
 
 # Install from a plugin repo with explicit path
-npx skillfish org/plugin-repo --path plugins/my-plugin/skills/skill-name
+npx skillfish add org/plugin-repo --path plugins/my-plugin/skills/skill-name
+
+# Install all skills non-interactively
+npx skillfish add org/plugin-repo --all --yes
 
 # Force reinstall
-npx skillfish user/skill --force
-```
+npx skillfish add user/skill --force
 
-## Private Repos
-
-Set `GITHUB_TOKEN` or `GH_TOKEN` environment variable:
-
-```bash
-GITHUB_TOKEN=ghp_xxx npx skillfish private-org/private-repo
+# JSON output for automation
+npx skillfish add owner/repo --json
 ```
 
 ## Discovery
@@ -102,6 +123,10 @@ DO_NOT_TRACK=1 npx skillfish owner/repo
 ```
 
 Telemetry is also automatically disabled in CI environments (`CI=true`).
+
+## Contributing
+
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "install-skill",
+  "name": "skillfish",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "install-skill",
+      "name": "skillfish",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -14,11 +14,12 @@
         "picocolors": "^1.1.1"
       },
       "bin": {
-        "install-skill": "dist/index.js"
+        "skillfish": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^4.0.17"
       },
       "engines": {
         "node": ">=18"
@@ -45,6 +46,837 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.3.tgz",
+      "integrity": "sha512-qyX8+93kK/7R5BEXPC2PjUt0+fS/VO2BVHjEHyIEWiYn88rcRBHmdLgoJjktBltgAf+NY7RfCGB1SoyKS/p9kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.3.tgz",
+      "integrity": "sha512-6sHrL42bjt5dHQzJ12Q4vMKfN+kUnZ0atHHnv4V0Wd9JMTk7FDzSY35+7qbz3ypQYMBPANbpGK7JpnWNnhGt8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.3.tgz",
+      "integrity": "sha512-1ht2SpGIjEl2igJ9AbNpPIKzb1B5goXOcmtD0RFxnwNuMxqkR6AUaaErZz+4o+FKmzxcSNBOLrzsICZVNYa1Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.3.tgz",
+      "integrity": "sha512-FYZ4iVunXxtT+CZqQoPVwPhH7549e/Gy7PIRRtq4t5f/vt54pX6eG9ebttRH6QSH7r/zxAFA4EZGlQ0h0FvXiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.3.tgz",
+      "integrity": "sha512-M/mwDCJ4wLsIgyxv2Lj7Len+UMHd4zAXu4GQ2UaCdksStglWhP61U3uowkaYBQBhVoNpwx5Hputo8eSqM7K82Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.3.tgz",
+      "integrity": "sha512-5jZT2c7jBCrMegKYTYTpni8mg8y3uY8gzeq2ndFOANwNuC/xJbVAoGKR9LhMDA0H3nIhvaqUoBEuJoICBudFrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.3.tgz",
+      "integrity": "sha512-YeGUhkN1oA+iSPzzhEjVPS29YbViOr8s4lSsFaZKLHswgqP911xx25fPOyE9+khmN6W4VeM0aevbDp4kkEoHiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.3.tgz",
+      "integrity": "sha512-eo0iOIOvcAlWB3Z3eh8pVM8hZ0oVkK3AjEM9nSrkSug2l15qHzF3TOwT0747omI6+CJJvl7drwZepT+re6Fy/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.3.tgz",
+      "integrity": "sha512-DJay3ep76bKUDImmn//W5SvpjRN5LmK/ntWyeJs/dcnwiiHESd3N4uteK9FDLf0S0W8E6Y0sVRXpOCoQclQqNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.3.tgz",
+      "integrity": "sha512-BKKWQkY2WgJ5MC/ayvIJTHjy0JUGb5efaHCUiG/39sSUvAYRBaO3+/EK0AZT1RF3pSj86O24GLLik9mAYu0IJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.3.tgz",
+      "integrity": "sha512-Q9nVlWtKAG7ISW80OiZGxTr6rYtyDSkauHUtvkQI6TNOJjFvpj4gcH+KaJihqYInnAzEEUetPQubRwHef4exVg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.3.tgz",
+      "integrity": "sha512-2H5LmhzrpC4fFRNwknzmmTvvyJPHwESoJgyReXeFoYYuIDfBhP29TEXOkCJE/KxHi27mj7wDUClNq78ue3QEBQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.3.tgz",
+      "integrity": "sha512-9S542V0ie9LCTznPYlvaeySwBeIEa7rDBgLHKZ5S9DBgcqdJYburabm8TqiqG6mrdTzfV5uttQRHcbKff9lWtA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.3.tgz",
+      "integrity": "sha512-ukxw+YH3XXpcezLgbJeasgxyTbdpnNAkrIlFGDl7t+pgCxZ89/6n1a+MxlY7CegU+nDgrgdqDelPRNQ/47zs0g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.3.tgz",
+      "integrity": "sha512-Iauw9UsTTvlF++FhghFJjqYxyXdggXsOqGpFBylaRopVpcbfyIIsNvkf9oGwfgIcf57z3m8+/oSYTo6HutBFNw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.3.tgz",
+      "integrity": "sha512-3OqKAHSEQXKdq9mQ4eajqUgNIK27VZPW3I26EP8miIzuKzCJ3aW3oEn2pzF+4/Hj/Moc0YDsOtBgT5bZ56/vcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.3.tgz",
+      "integrity": "sha512-0CM8dSVzVIaqMcXIFej8zZrSFLnGrAE8qlNbbHfTw1EEPnFTg1U1ekI0JdzjPyzSfUsHWtodilQQG/RA55berA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.3.tgz",
+      "integrity": "sha512-+fgJE12FZMIgBaKIAGd45rxf+5ftcycANJRWk8Vz0NnMTM5rADPGuRFTYar+Mqs560xuART7XsX2lSACa1iOmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.3.tgz",
+      "integrity": "sha512-tMD7NnbAolWPzQlJQJjVFh/fNH3K/KnA7K8gv2dJWCwwnaK6DFCYST1QXYWfu5V0cDwarWC8Sf/cfMHniNq21A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.3.tgz",
+      "integrity": "sha512-u5KsqxOxjEeIbn7bUK1MPM34jrnPwjeqgyin4/N6e/KzXKfpE9Mi0nCxcQjaM9lLmPcHmn/xx1yOjgTMtu1jWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.3.tgz",
+      "integrity": "sha512-vo54aXwjpTtsAnb3ca7Yxs9t2INZg7QdXN/7yaoG7nPGbOBXYXQY41Km+S1Ov26vzOAzLcAjmMdjyEqS1JkVhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.3.tgz",
+      "integrity": "sha512-HI+PIVZ+m+9AgpnY3pt6rinUdRYrGHvmVdsNQ4odNqQ/eRF78DVpMR7mOq7nW06QxpczibwBmeQzB68wJ+4W4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.3.tgz",
+      "integrity": "sha512-vRByotbdMo3Wdi+8oC2nVxtc3RkkFKrGaok+a62AT8lz/YBuQjaVYAS5Zcs3tPzW43Vsf9J0wehJbUY5xRSekA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.3.tgz",
+      "integrity": "sha512-POZHq7UeuzMJljC5NjKi8vKMFN6/5EOqcX1yGntNLp7rUTpBAXQ1hW8kWPFxYLv07QMcNM75xqVLGPWQq6TKFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.3.tgz",
+      "integrity": "sha512-aPFONczE4fUFKNXszdvnd2GqKEYQdV5oEsIbKPujJmWlCI9zEsv1Otig8RKK+X9bed9gFUN6LAeN4ZcNuu4zjg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.28",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.28.tgz",
@@ -53,6 +885,137 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
+      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
+      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.17",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
+      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
+      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
+      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.17",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
+      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
+      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.17",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/degit": {
@@ -67,10 +1030,253 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.55.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.3.tgz",
+      "integrity": "sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.55.3",
+        "@rollup/rollup-android-arm64": "4.55.3",
+        "@rollup/rollup-darwin-arm64": "4.55.3",
+        "@rollup/rollup-darwin-x64": "4.55.3",
+        "@rollup/rollup-freebsd-arm64": "4.55.3",
+        "@rollup/rollup-freebsd-x64": "4.55.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.3",
+        "@rollup/rollup-linux-arm64-musl": "4.55.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.3",
+        "@rollup/rollup-linux-loong64-musl": "4.55.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.3",
+        "@rollup/rollup-linux-x64-gnu": "4.55.3",
+        "@rollup/rollup-linux-x64-musl": "4.55.3",
+        "@rollup/rollup-openbsd-x64": "4.55.3",
+        "@rollup/rollup-openharmony-arm64": "4.55.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.3",
+        "@rollup/rollup-win32-x64-gnu": "4.55.3",
+        "@rollup/rollup-win32-x64-msvc": "4.55.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -78,6 +1284,74 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -99,6 +1373,176 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
+      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.17",
+        "@vitest/mocker": "4.0.17",
+        "@vitest/pretty-format": "4.0.17",
+        "@vitest/runner": "4.0.17",
+        "@vitest/snapshot": "4.0.17",
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.17",
+        "@vitest/browser-preview": "4.0.17",
+        "@vitest/browser-webdriverio": "4.0.17",
+        "@vitest/ui": "4.0.17",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "cli",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.0.17"
   }
 }

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidPath,
+  isGitTreeResponse,
+  parseFrontmatter,
+  deriveSkillName,
+  toTitleCase,
+  truncate,
+  extractSkillPaths,
+} from '../utils.js';
+
+describe('isValidPath', () => {
+  it('accepts valid relative paths', () => {
+    expect(isValidPath('skills/my-skill')).toBe(true);
+    expect(isValidPath('SKILL.md')).toBe(true);
+    expect(isValidPath('plugins/foo/skills/bar')).toBe(true);
+    expect(isValidPath('my_skill')).toBe(true);
+    expect(isValidPath('skill.v2')).toBe(true);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(isValidPath('/etc/passwd')).toBe(false);
+    expect(isValidPath('/home/user/skills')).toBe(false);
+  });
+
+  it('rejects directory traversal attempts', () => {
+    expect(isValidPath('../etc/passwd')).toBe(false);
+    expect(isValidPath('skills/../../../etc/passwd')).toBe(false);
+    expect(isValidPath('..\\windows\\system32')).toBe(false);
+  });
+
+  it('rejects paths with special characters', () => {
+    expect(isValidPath('skill;rm -rf /')).toBe(false);
+    expect(isValidPath('skill`whoami`')).toBe(false);
+    expect(isValidPath('skill$(cat /etc/passwd)')).toBe(false);
+    expect(isValidPath('skill|evil')).toBe(false);
+  });
+
+  it('rejects paths with double slashes', () => {
+    expect(isValidPath('skills//evil')).toBe(false);
+  });
+
+  it('rejects paths starting with slash', () => {
+    expect(isValidPath('/skills')).toBe(false);
+  });
+});
+
+describe('isGitTreeResponse', () => {
+  it('accepts valid tree response', () => {
+    const validResponse = {
+      tree: [
+        { path: 'SKILL.md', type: 'blob' },
+        { path: 'skills/foo/SKILL.md', type: 'blob' },
+      ],
+      sha: 'abc123',
+    };
+    expect(isGitTreeResponse(validResponse)).toBe(true);
+  });
+
+  it('accepts response with empty tree', () => {
+    expect(isGitTreeResponse({ tree: [] })).toBe(true);
+  });
+
+  it('accepts response without tree field', () => {
+    expect(isGitTreeResponse({ sha: 'abc123' })).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(isGitTreeResponse(null)).toBe(false);
+  });
+
+  it('rejects non-object', () => {
+    expect(isGitTreeResponse('string')).toBe(false);
+    expect(isGitTreeResponse(123)).toBe(false);
+    expect(isGitTreeResponse(undefined)).toBe(false);
+  });
+
+  it('rejects tree that is not an array', () => {
+    expect(isGitTreeResponse({ tree: 'not an array' })).toBe(false);
+    expect(isGitTreeResponse({ tree: {} })).toBe(false);
+  });
+
+  it('rejects tree items without required fields', () => {
+    expect(isGitTreeResponse({ tree: [{ path: 'test' }] })).toBe(false); // missing type
+    expect(isGitTreeResponse({ tree: [{ type: 'blob' }] })).toBe(false); // missing path
+    expect(isGitTreeResponse({ tree: [{ path: 123, type: 'blob' }] })).toBe(false); // path not string
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('parses name and description', () => {
+    const content = `---
+name: My Skill
+description: A helpful skill
+---
+
+# Skill Content`;
+    expect(parseFrontmatter(content)).toEqual({
+      name: 'My Skill',
+      description: 'A helpful skill',
+    });
+  });
+
+  it('handles quoted values', () => {
+    const content = `---
+name: "Quoted Skill"
+description: 'Single quoted'
+---`;
+    expect(parseFrontmatter(content)).toEqual({
+      name: 'Quoted Skill',
+      description: 'Single quoted',
+    });
+  });
+
+  it('returns empty object for no frontmatter', () => {
+    const content = '# Just a Heading\n\nSome content';
+    expect(parseFrontmatter(content)).toEqual({});
+  });
+
+  it('handles missing fields', () => {
+    const content = `---
+name: Only Name
+---`;
+    expect(parseFrontmatter(content)).toEqual({ name: 'Only Name' });
+  });
+
+  it('handles Windows line endings', () => {
+    const content = '---\r\nname: Windows Skill\r\ndescription: CRLF test\r\n---\r\n';
+    expect(parseFrontmatter(content)).toEqual({
+      name: 'Windows Skill',
+      description: 'CRLF test',
+    });
+  });
+});
+
+describe('deriveSkillName', () => {
+  it('returns repo name for root SKILL.md', () => {
+    expect(deriveSkillName('SKILL.md', 'my-repo')).toBe('my-repo');
+    expect(deriveSkillName('./SKILL.md', 'my-repo')).toBe('my-repo');
+  });
+
+  it('extracts folder name from path', () => {
+    expect(deriveSkillName('skills/code-review', 'repo')).toBe('code-review');
+    expect(deriveSkillName('plugins/foo/skills/bar', 'repo')).toBe('bar');
+    expect(deriveSkillName('skills/my-skill/SKILL.md', 'repo')).toBe('my-skill');
+  });
+
+  it('falls back to repo name for invalid folder names', () => {
+    expect(deriveSkillName('skills/bad name with spaces', 'fallback-repo')).toBe('fallback-repo');
+  });
+});
+
+describe('toTitleCase', () => {
+  it('converts kebab-case to Title Case', () => {
+    expect(toTitleCase('skill-lookup')).toBe('Skill Lookup');
+    expect(toTitleCase('my-cool-skill')).toBe('My Cool Skill');
+  });
+
+  it('converts snake_case to Title Case', () => {
+    expect(toTitleCase('my_cool_skill')).toBe('My Cool Skill');
+  });
+
+  it('handles mixed separators', () => {
+    expect(toTitleCase('skill-name_v2')).toBe('Skill Name V2');
+  });
+
+  it('handles single word', () => {
+    expect(toTitleCase('skill')).toBe('Skill');
+  });
+
+  it('handles already capitalized', () => {
+    expect(toTitleCase('SKILL')).toBe('SKILL');
+  });
+});
+
+describe('truncate', () => {
+  it('returns short text unchanged', () => {
+    expect(truncate('short', 10)).toBe('short');
+    expect(truncate('exactly10!', 10)).toBe('exactly10!');
+  });
+
+  it('truncates long text with ellipsis', () => {
+    expect(truncate('This is a long description that needs truncation', 20)).toBe('This is a long desc…');
+  });
+
+  it('trims whitespace before ellipsis', () => {
+    // With maxLength=15, slice to 14, then trim, add ellipsis
+    // "Word boundary " (14 chars) -> trimmed -> "Word boundary" + "…"
+    expect(truncate('Word boundary test here', 15)).toBe('Word boundary…');
+  });
+});
+
+describe('extractSkillPaths', () => {
+  it('extracts SKILL.md paths from tree', () => {
+    const response = {
+      tree: [
+        { path: 'README.md', type: 'blob' },
+        { path: 'SKILL.md', type: 'blob' },
+        { path: 'skills/foo/SKILL.md', type: 'blob' },
+        { path: 'skills/bar', type: 'tree' }, // directory, not blob
+        { path: 'skills/bar/SKILL.md', type: 'blob' },
+      ],
+    };
+
+    const paths = extractSkillPaths(response);
+    expect(paths).toEqual([
+      'SKILL.md',
+      'skills/foo/SKILL.md',
+      'skills/bar/SKILL.md',
+    ]);
+  });
+
+  it('returns empty array for empty tree', () => {
+    expect(extractSkillPaths({ tree: [] })).toEqual([]);
+  });
+
+  it('returns empty array for no tree', () => {
+    expect(extractSkillPaths({})).toEqual([]);
+  });
+
+  it('filters out non-blob types', () => {
+    const response = {
+      tree: [
+        { path: 'SKILL.md', type: 'tree' }, // directory with same name
+        { path: 'real/SKILL.md', type: 'blob' },
+      ],
+    };
+    expect(extractSkillPaths(response)).toEqual(['real/SKILL.md']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,244 +1,413 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, cpSync, rmSync, lstatSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, cpSync, rmSync, lstatSync, readdirSync, readFileSync } from 'fs';
 import { homedir } from 'os';
-import { join, basename, dirname, normalize, isAbsolute } from 'path';
+import { join, dirname, basename } from 'path';
 import { randomUUID } from 'crypto';
+import { fileURLToPath } from 'url';
 import degit from 'degit';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { trackInstall } from './telemetry.js';
+import {
+  isValidPath,
+  isGitTreeResponse,
+  parseFrontmatter,
+  deriveSkillName,
+  toTitleCase,
+  truncate,
+  extractSkillPaths,
+  sleep,
+  batchMap,
+  type GitTreeResponse,
+} from './utils.js';
 
-const VERSION = '1.0.0';
+// Read version from package.json (single source of truth)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+const VERSION: string = packageJson.version;
 
-// Agent configuration
+// === Constants ===
+const API_TIMEOUT_MS = 10000;
+const MAX_RETRIES = 3;
+const RETRY_DELAYS_MS = [1000, 2000, 4000]; // Exponential backoff
+const DEFAULT_BRANCHES = ['main', 'master'] as const;
+const SKILL_FILENAME = 'SKILL.md';
+
+// === Exit Codes ===
+const EXIT_SUCCESS = 0;
+const EXIT_GENERAL_ERROR = 1;
+const EXIT_INVALID_ARGS = 2;
+const EXIT_NETWORK_ERROR = 3;
+const EXIT_NOT_FOUND = 4;
+const EXIT_CANCELLED = 0; // User cancellation is not an error
+
+// Type imports from utils.js are used for GitTreeResponse
+
+/**
+ * Fetch with retry and exponential backoff.
+ * Retries on network errors and 5xx responses.
+ */
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  maxRetries: number = MAX_RETRIES
+): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+
+      // Success or client error (4xx) - don't retry
+      if (res.ok || (res.status >= 400 && res.status < 500)) {
+        return res;
+      }
+
+      // Server error (5xx) - retry
+      if (res.status >= 500) {
+        lastError = new Error(`Server error: ${res.status}`);
+        if (attempt < maxRetries - 1) {
+          await sleep(RETRY_DELAYS_MS[attempt] || 4000);
+          continue;
+        }
+      }
+
+      return res;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+
+      // Network error - retry
+      if (attempt < maxRetries - 1) {
+        await sleep(RETRY_DELAYS_MS[attempt] || 4000);
+        continue;
+      }
+    }
+  }
+
+  throw lastError || new Error('Max retries exceeded');
+}
+
+// === JSON Output Support ===
+type JsonOutput = {
+  success: boolean;
+  installed: Array<{ skill: string; agent: string; path: string }>;
+  skipped: Array<{ skill: string; agent: string; reason: string }>;
+  errors: string[];
+  skills_found?: string[];
+};
+
+let jsonMode = false;
+let jsonOutput: JsonOutput = {
+  success: true,
+  installed: [],
+  skipped: [],
+  errors: [],
+};
+
+function resetJsonOutput(): void {
+  jsonOutput = {
+    success: true,
+    installed: [],
+    skipped: [],
+    errors: [],
+  };
+}
+
+function addJsonError(message: string): void {
+  jsonOutput.errors.push(message);
+  jsonOutput.success = false;
+}
+
+function outputJson(): void {
+  console.log(JSON.stringify(jsonOutput, null, 2));
+}
+
+// Agent configuration - data-driven for easier maintenance
+// Detection checks home directory (agent installed globally) and cwd (local project)
+// Supports all agents from the Agent Skills specification: https://agentskills.io
+type AgentConfig = {
+  readonly name: string;
+  readonly dir: string;
+  readonly homePaths: readonly string[];  // Paths to check in ~/
+  readonly cwdPaths: readonly string[];   // Paths to check in ./
+};
+
+const AGENT_CONFIGS: readonly AgentConfig[] = [
+  // === Primary Agents (widely used) ===
+  { name: 'Claude Code', dir: '.claude/skills', homePaths: ['.claude/settings.json', '.claude/projects.json', '.claude/credentials.json'], cwdPaths: ['.claude'] },
+  { name: 'Cursor', dir: '.cursor/skills', homePaths: ['.cursor/extensions', '.cursor/argv.json'], cwdPaths: ['.cursor'] },
+  { name: 'Windsurf', dir: '.codeium/windsurf/skills', homePaths: ['.codeium/windsurf/config.json', '.codeium/windsurf/argv.json'], cwdPaths: ['.codeium/windsurf'] },
+  { name: 'Codex', dir: '.codex/skills', homePaths: ['.codex/config.json', '.codex/settings.json', '.codex'], cwdPaths: ['.codex'] },
+  { name: 'GitHub Copilot', dir: '.github/skills', homePaths: ['.copilot/config.json', '.copilot'], cwdPaths: ['.github/skills', '.github/copilot-instructions.md'] },
+  { name: 'Gemini CLI', dir: '.gemini/skills', homePaths: ['.gemini'], cwdPaths: ['.gemini'] },
+  { name: 'OpenCode', dir: '.opencode/skills', homePaths: ['.config/opencode', '.opencode'], cwdPaths: ['.opencode'] },
+  { name: 'Goose', dir: '.goose/skills', homePaths: ['.config/goose'], cwdPaths: ['.goose'] },
+  // === Secondary Agents ===
+  { name: 'Amp', dir: '.agents/skills', homePaths: ['.config/amp'], cwdPaths: ['.agents'] },
+  { name: 'Roo Code', dir: '.roo/skills', homePaths: ['.roo'], cwdPaths: ['.roo'] },
+  { name: 'Kiro CLI', dir: '.kiro/skills', homePaths: ['.kiro'], cwdPaths: ['.kiro'] },
+  { name: 'Kilo Code', dir: '.kilocode/skills', homePaths: ['.kilocode'], cwdPaths: ['.kilocode'] },
+  { name: 'Trae', dir: '.trae/skills', homePaths: ['.trae'], cwdPaths: ['.trae'] },
+  { name: 'Cline', dir: '.cline/skills', homePaths: ['.cline/settings.json', '.cline'], cwdPaths: ['.cline'] },
+  // === Additional Agents ===
+  { name: 'Antigravity', dir: '.gemini/antigravity/skills', homePaths: ['.gemini/antigravity'], cwdPaths: ['.agent'] },
+  { name: 'Droid', dir: '.factory/skills', homePaths: ['.factory'], cwdPaths: ['.factory'] },
+  { name: 'Clawdbot', dir: '.clawdbot/skills', homePaths: ['.clawdbot'], cwdPaths: ['.clawdbot'] },
+];
+
+/**
+ * Check if an agent is detected on the system.
+ * Checks home directory paths first, then current working directory paths.
+ */
+function detectAgent(config: AgentConfig): boolean {
+  const home = homedir();
+  const cwd = process.cwd();
+
+  return config.homePaths.some(p => existsSync(join(home, p))) ||
+         config.cwdPaths.some(p => existsSync(join(cwd, p)));
+}
+
+// Runtime agent type with detect function
 type Agent = {
   readonly name: string;
   readonly dir: string;
   readonly detect: () => boolean;
 };
 
-// Detection checks for:
-// 1. Agent config files in home directory (agent is installed globally)
-// 2. Existing skill directories in current project (agent was used locally before)
-// Supports all agents from the Agent Skills specification: https://agentskills.io
-const AGENTS: readonly Agent[] = [
-  // === Primary Agents (widely used) ===
-  {
-    name: 'Claude Code',
-    dir: '.claude/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.claude', 'settings.json')) ||
-      existsSync(join(homedir(), '.claude', 'projects.json')) ||
-      existsSync(join(homedir(), '.claude', 'credentials.json')) ||
-      existsSync(join(process.cwd(), '.claude')),
-  },
-  {
-    name: 'Cursor',
-    dir: '.cursor/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.cursor', 'extensions')) ||
-      existsSync(join(homedir(), '.cursor', 'argv.json')) ||
-      existsSync(join(process.cwd(), '.cursor')),
-  },
-  {
-    name: 'Windsurf',
-    dir: '.codeium/windsurf/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.codeium', 'windsurf', 'config.json')) ||
-      existsSync(join(homedir(), '.codeium', 'windsurf', 'argv.json')) ||
-      existsSync(join(process.cwd(), '.codeium', 'windsurf')),
-  },
-  {
-    name: 'Codex',
-    dir: '.codex/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.codex', 'config.json')) ||
-      existsSync(join(homedir(), '.codex', 'settings.json')) ||
-      existsSync(join(homedir(), '.codex')) ||
-      existsSync(join(process.cwd(), '.codex')),
-  },
-  {
-    name: 'GitHub Copilot',
-    dir: '.github/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.copilot', 'config.json')) ||
-      existsSync(join(homedir(), '.copilot')) ||
-      existsSync(join(process.cwd(), '.github', 'skills')) ||
-      existsSync(join(process.cwd(), '.github', 'copilot-instructions.md')),
-  },
-  {
-    name: 'Gemini CLI',
-    dir: '.gemini/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.gemini')) ||
-      existsSync(join(process.cwd(), '.gemini')),
-  },
-  {
-    name: 'OpenCode',
-    dir: '.opencode/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.config', 'opencode')) ||
-      existsSync(join(homedir(), '.opencode')) ||
-      existsSync(join(process.cwd(), '.opencode')),
-  },
-  {
-    name: 'Goose',
-    dir: '.goose/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.config', 'goose')) ||
-      existsSync(join(process.cwd(), '.goose')),
-  },
-  // === Secondary Agents ===
-  {
-    name: 'Amp',
-    dir: '.agents/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.config', 'amp')) ||
-      existsSync(join(process.cwd(), '.agents')),
-  },
-  {
-    name: 'Roo Code',
-    dir: '.roo/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.roo')) ||
-      existsSync(join(process.cwd(), '.roo')),
-  },
-  {
-    name: 'Kiro CLI',
-    dir: '.kiro/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.kiro')) ||
-      existsSync(join(process.cwd(), '.kiro')),
-  },
-  {
-    name: 'Kilo Code',
-    dir: '.kilocode/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.kilocode')) ||
-      existsSync(join(process.cwd(), '.kilocode')),
-  },
-  {
-    name: 'Trae',
-    dir: '.trae/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.trae')) ||
-      existsSync(join(process.cwd(), '.trae')),
-  },
-  {
-    name: 'Cline',
-    dir: '.cline/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.cline', 'settings.json')) ||
-      existsSync(join(homedir(), '.cline')) ||
-      existsSync(join(process.cwd(), '.cline')),
-  },
-  // === Additional Agents ===
-  {
-    name: 'Antigravity',
-    dir: '.gemini/antigravity/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.gemini', 'antigravity')) ||
-      existsSync(join(process.cwd(), '.agent')),
-  },
-  {
-    name: 'Droid',
-    dir: '.factory/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.factory')) ||
-      existsSync(join(process.cwd(), '.factory')),
-  },
-  {
-    name: 'Clawdbot',
-    dir: '.clawdbot/skills',
-    detect: () =>
-      existsSync(join(homedir(), '.clawdbot')) ||
-      existsSync(join(process.cwd(), '.clawdbot')),
-  },
-];
-
-/**
- * Validates a path to prevent directory traversal attacks.
- * Ensures path doesn't escape the intended directory.
- */
-function isValidPath(pathStr: string): boolean {
-  // Reject absolute paths
-  if (isAbsolute(pathStr)) return false;
-
-  // Normalize and check for directory traversal
-  const normalized = normalize(pathStr);
-  if (normalized.startsWith('..') || normalized.includes('/../')) return false;
-
-  // Only allow alphanumeric, dots, hyphens, underscores, and forward slashes
-  if (!/^[\w./-]+$/.test(pathStr)) return false;
-
-  // Reject paths that could be problematic
-  if (pathStr.includes('//') || pathStr.startsWith('/')) return false;
-
-  return true;
-}
+// Build AGENTS array from config (preserves existing API)
+const AGENTS: readonly Agent[] = AGENT_CONFIGS.map(config => ({
+  name: config.name,
+  dir: config.dir,
+  detect: () => detectAgent(config),
+}));
 
 /**
  * Recursively copies a directory while skipping symlinks for security.
  * This prevents symlink attacks where malicious repos could link to sensitive files.
+ *
+ * SECURITY: Uses double-check pattern to minimize TOCTOU race window.
+ * The second lstatSync check immediately before cpSync reduces (but doesn't
+ * eliminate) the window for a race condition attack.
  */
-function safeCopyDir(src: string, dest: string): void {
-  mkdirSync(dest, { recursive: true });
+function safeCopyDir(src: string, dest: string, warnings: string[] = []): string[] {
+  mkdirSync(dest, { recursive: true, mode: 0o700 });
 
   const entries = readdirSync(src, { withFileTypes: true });
   for (const entry of entries) {
     const srcPath = join(src, entry.name);
     const destPath = join(dest, entry.name);
 
-    // Skip symlinks for security
+    // First check: Skip symlinks for security
     if (entry.isSymbolicLink()) {
-      console.log(`  ${pc.yellow('!')} Skipped symlink: ${pc.dim(entry.name)}`);
+      const warning = `Skipped symlink: ${entry.name}`;
+      warnings.push(warning);
+      if (!jsonMode) {
+        console.log(`  ${pc.yellow('!')} ${warning}`);
+      }
       continue;
     }
 
     if (entry.isDirectory()) {
-      safeCopyDir(srcPath, destPath);
+      safeCopyDir(srcPath, destPath, warnings);
     } else if (entry.isFile()) {
-      cpSync(srcPath, destPath);
+      // SECURITY: Second check immediately before copy to minimize TOCTOU window
+      // This doesn't eliminate the race but significantly reduces the attack window
+      try {
+        const stat = lstatSync(srcPath);
+        if (stat.isSymbolicLink()) {
+          const warning = `Skipped symlink (detected on copy): ${entry.name}`;
+          warnings.push(warning);
+          if (!jsonMode) {
+            console.log(`  ${pc.yellow('!')} ${warning}`);
+          }
+          continue;
+        }
+        cpSync(srcPath, destPath);
+      } catch (err) {
+        // File may have been removed/changed between readdir and copy
+        const warning = `Could not copy ${entry.name}: ${err instanceof Error ? err.message : 'unknown error'}`;
+        warnings.push(warning);
+        if (!jsonMode) {
+          console.log(`  ${pc.yellow('!')} ${warning}`);
+        }
+      }
     }
   }
+
+  return warnings;
+}
+
+/**
+ * List installed skills for all detected agents.
+ */
+async function listInstalledSkills(baseDir: string): Promise<void> {
+  const detected = AGENTS.filter(a => a.detect());
+
+  if (detected.length === 0) {
+    if (jsonMode) {
+      jsonOutput.errors.push('No agents detected');
+      outputJson();
+    } else {
+      p.log.error('No agents detected. Install Claude Code, Cursor, or another supported agent first.');
+    }
+    process.exit(EXIT_GENERAL_ERROR);
+  }
+
+  type InstalledSkill = { agent: string; skill: string; path: string };
+  const installed: InstalledSkill[] = [];
+
+  for (const agent of detected) {
+    const skillDir = join(baseDir, agent.dir);
+    if (existsSync(skillDir)) {
+      try {
+        const skills = readdirSync(skillDir, { withFileTypes: true })
+          .filter(entry => entry.isDirectory())
+          .map(entry => entry.name);
+
+        for (const skill of skills) {
+          const skillPath = join(skillDir, skill);
+          const hasSkillMd = existsSync(join(skillPath, SKILL_FILENAME));
+          if (hasSkillMd) {
+            installed.push({
+              agent: agent.name,
+              skill,
+              path: skillPath,
+            });
+          }
+        }
+      } catch {
+        // Directory might not be readable, skip it
+      }
+    }
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify({
+      success: true,
+      installed,
+      agents_detected: detected.map(a => a.name),
+    }, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  if (installed.length === 0) {
+    p.log.info('No skills installed');
+    return;
+  }
+
+  console.log();
+  p.intro(`${pc.bgCyan(pc.black(' skillfish '))} ${pc.dim('Installed skills')}`);
+
+  // Group by agent
+  const byAgent = new Map<string, string[]>();
+  for (const item of installed) {
+    const list = byAgent.get(item.agent) || [];
+    list.push(item.skill);
+    byAgent.set(item.agent, list);
+  }
+
+  for (const [agent, skills] of byAgent) {
+    console.log();
+    console.log(pc.bold(agent));
+    for (const skill of skills) {
+      console.log(`  ${pc.green('•')} ${skill}`);
+    }
+  }
+
+  console.log();
+  p.outro(`${pc.cyan(installed.length.toString())} skill${installed.length === 1 ? '' : 's'} installed`);
 }
 
 async function main(): Promise<void> {
-  const [, , repoArg, ...flags] = process.argv;
+  const [, , command, ...args] = process.argv;
 
-  // Handle --version flag
-  if (repoArg === '--version' || repoArg === '-v') {
-    console.log(`skillfish v${VERSION}`);
-    process.exit(0);
+  // Check for --json flag early (affects all output)
+  jsonMode = args.includes('--json') || command === '--json';
+  if (jsonMode) {
+    resetJsonOutput();
   }
 
-  if (!repoArg || repoArg === '--help' || repoArg === '-h') {
-    console.log(`
+  // Handle --version flag
+  if (command === '--version' || command === '-v') {
+    if (jsonMode) {
+      console.log(JSON.stringify({ version: VERSION }));
+    } else {
+      console.log(`skillfish v${VERSION}`);
+    }
+    process.exit(EXIT_SUCCESS);
+  }
+
+  // Handle list subcommand
+  if (command === 'list') {
+    const projectFlag = args.includes('--project');
+    const globalFlag = args.includes('--global');
+    const baseDir = projectFlag ? process.cwd() : (globalFlag ? homedir() : homedir());
+    await listInstalledSkills(baseDir);
+    process.exit(EXIT_SUCCESS);
+  }
+
+  // Handle add subcommand
+  if (command === 'add') {
+    const [repoArg, ...flags] = args;
+    if (!repoArg || repoArg.startsWith('--')) {
+      const errorMsg = 'Missing repository. Usage: skillfish add <owner/repo>';
+      if (jsonMode) {
+        addJsonError(errorMsg);
+        outputJson();
+      } else {
+        console.error(errorMsg);
+      }
+      process.exit(EXIT_INVALID_ARGS);
+    }
+    await installSkillFromRepo(repoArg, flags);
+    return;
+  }
+
+  // Show help for no command, --help, -h, or unknown commands
+  const helpText = `
 ${pc.bold('skillfish')} v${VERSION} - Install AI agent skills from GitHub
 
 ${pc.dim('Usage:')}
-  skillfish ${pc.cyan('<owner/repo>')} [options]
-  skillfish ${pc.cyan('<owner/repo/path/to/skill>')}
+  skillfish add ${pc.cyan('<owner/repo>')} [options]
+  skillfish add ${pc.cyan('<owner/repo/plugin/skill>')}
+  skillfish list [--project|--global]
+
+${pc.dim('Commands:')}
+  add             Install a skill from GitHub
+  list            List installed skills
 
 ${pc.dim('Options:')}
   --path <path>   Path to skill directory within repo
+  --all           Install all skills (for repos with multiple skills)
   --force         Overwrite existing skills
+  --yes, -y       Skip confirmation prompts (trust source)
   --project       Install to current project (./)
   --global        Install to home directory (~/)
+  --json          Output in JSON format (for automation)
   --version, -v   Show version
   --help, -h      Show help
 
 ${pc.dim('Examples:')}
-  skillfish anthropics/claude-code
-  skillfish f/awesome-chatgpt-prompts
-  skillfish owner/repo --path skills/my-skill
-  skillfish owner/repo --force --project
-`);
-    process.exit(repoArg ? 0 : 1);
+  skillfish add anthropics/claude-code
+  skillfish add owner/repo --path skills/my-skill
+  skillfish add owner/repo --all --yes
+  skillfish add owner/repo --force --project
+  skillfish add owner/repo --json
+  skillfish list --global
+`;
+  if (jsonMode) {
+    console.log(JSON.stringify({ help: helpText.replace(/\x1b\[[0-9;]*m/g, '') }));
+  } else {
+    console.log(helpText);
   }
+  process.exit(command === '--help' || command === '-h' ? EXIT_SUCCESS : EXIT_INVALID_ARGS);
+}
 
-  // Show banner and intro (TTY only)
-  if (process.stdout.isTTY) {
+async function installSkillFromRepo(repoArg: string, flags: string[]): Promise<void> {
+
+  // Show banner and intro (TTY only, not in JSON mode)
+  if (process.stdout.isTTY && !jsonMode) {
     console.log();
     console.log(pc.cyan('     ≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋'));
     console.log(`       ${pc.cyan('><>')}  ${pc.bold('SKILL FISH')}  ${pc.cyan('><>')}`);
@@ -248,20 +417,34 @@ ${pc.dim('Examples:')}
   }
 
   const force = flags.includes('--force');
+  const trustSource = flags.includes('--yes') || flags.includes('-y');
+  const installAll = flags.includes('--all');
   const projectFlag = flags.includes('--project');
   const globalFlag = flags.includes('--global');
   const pathIdx = flags.indexOf('--path');
   let explicitPath: string | null = null;
   if (pathIdx !== -1) {
     if (pathIdx + 1 >= flags.length || flags[pathIdx + 1]?.startsWith('--')) {
-      console.error('--path requires a value');
-      process.exit(1);
+      const errorMsg = '--path requires a value';
+      if (jsonMode) {
+        addJsonError(errorMsg);
+        outputJson();
+      } else {
+        console.error(errorMsg);
+      }
+      process.exit(EXIT_INVALID_ARGS);
     }
     const pathValue = flags[pathIdx + 1];
     // Security: validate path to prevent directory traversal
     if (!isValidPath(pathValue)) {
-      console.error('Invalid --path value. Path must be relative and contain only safe characters.');
-      process.exit(1);
+      const errorMsg = 'Invalid --path value. Path must be relative and contain only safe characters.';
+      if (jsonMode) {
+        addJsonError(errorMsg);
+        outputJson();
+      } else {
+        console.error(errorMsg);
+      }
+      process.exit(EXIT_INVALID_ARGS);
     }
     explicitPath = pathValue;
   }
@@ -279,29 +462,52 @@ ${pc.dim('Examples:')}
     repo = r;
     // Security: validate plugin and skill names
     if (!/^[\w.-]+$/.test(plugin) || !/^[\w.-]+$/.test(skill)) {
-      console.error('Invalid plugin or skill name. Use only alphanumeric characters, dots, hyphens, and underscores.');
-      process.exit(1);
+      const errorMsg = 'Invalid plugin or skill name. Use only alphanumeric characters, dots, hyphens, and underscores.';
+      if (jsonMode) {
+        addJsonError(errorMsg);
+        outputJson();
+      } else {
+        console.error(errorMsg);
+      }
+      process.exit(EXIT_INVALID_ARGS);
     }
     explicitPath = explicitPath || `plugins/${plugin}/skills/${skill}`;
-    console.log(`Detected full path format: ${plugin}/${skill}`);
+    if (!jsonMode) {
+      console.log(`Installing skill from: ${plugin}/${skill}`);
+    }
   } else {
-    console.error('Invalid format. Use: owner/repo or owner/repo/plugin/skill');
-    process.exit(1);
+    const errorMsg = 'Invalid format. Use: owner/repo or owner/repo/plugin/skill';
+    if (jsonMode) {
+      addJsonError(errorMsg);
+      outputJson();
+    } else {
+      console.error(errorMsg);
+    }
+    process.exit(EXIT_INVALID_ARGS);
   }
 
   // Validate (security: prevent injection)
   if (!owner || !repo || !/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
-    console.error('Invalid repository format. Use: owner/repo');
-    process.exit(1);
+    const errorMsg = 'Invalid repository format. Use: owner/repo';
+    if (jsonMode) {
+      addJsonError(errorMsg);
+      outputJson();
+    } else {
+      console.error(errorMsg);
+    }
+    process.exit(EXIT_INVALID_ARGS);
   }
 
   // 1. Discover or select skills
   const skillPaths = explicitPath
     ? [explicitPath]
-    : await discoverSkillPaths(owner, repo);
+    : await discoverSkillPaths(owner, repo, installAll);
 
   if (!skillPaths || skillPaths.length === 0) {
-    process.exit(1);
+    if (jsonMode) {
+      outputJson();
+    }
+    process.exit(EXIT_NOT_FOUND);
   }
 
   // 2. Determine install location (global vs project)
@@ -311,16 +517,24 @@ ${pc.dim('Examples:')}
   const detected = AGENTS.filter(a => a.detect());
 
   if (detected.length === 0) {
-    p.log.error('No agents detected. Install Claude Code, Cursor, or another supported agent first.');
-    p.outro(pc.dim('https://skill.fish/agents'));
-    process.exit(1);
+    const errorMsg = 'No agents detected. Install Claude Code, Cursor, or another supported agent first.';
+    if (jsonMode) {
+      addJsonError(errorMsg);
+      outputJson();
+    } else {
+      p.log.error(errorMsg);
+      p.outro(pc.dim('https://skill.fish/agents'));
+    }
+    process.exit(EXIT_GENERAL_ERROR);
   }
 
   let targetAgents: readonly Agent[];
 
-  if (!process.stdin.isTTY) {
-    // Non-TTY: use all detected agents
-    console.log(`Installing to ${detected.length} agent(s): ${detected.map(a => a.name).join(', ')}`);
+  if (!process.stdin.isTTY || jsonMode) {
+    // Non-TTY or JSON mode: use all detected agents
+    if (!jsonMode) {
+      console.log(`Installing to ${detected.length} agent(s): ${detected.map(a => a.name).join(', ')}`);
+    }
     targetAgents = detected;
   } else {
     // Interactive: let user choose from detected agents
@@ -334,6 +548,19 @@ ${pc.dim('Examples:')}
 
   for (const skillPath of skillPaths) {
     const skillName = deriveSkillName(skillPath, repo);
+
+    // SECURITY: Ask for confirmation before installation (unless --yes is used)
+    if (!trustSource && !jsonMode && process.stdin.isTTY) {
+      const shouldInstall = await confirmInstall(owner, repo, skillName);
+      if (!shouldInstall) {
+        if (!jsonMode) {
+          p.log.warn(`Skipped ${pc.bold(skillName)} (not confirmed)`);
+        }
+        jsonOutput.skipped.push({ skill: skillName, agent: 'all', reason: 'User declined' });
+        continue;
+      }
+    }
+
     const result = await installSkill(owner, repo, skillPath, skillName, targetAgents, force, baseDir);
     totalInstalled += result.installed;
     totalSkipped += result.skipped;
@@ -348,29 +575,37 @@ ${pc.dim('Examples:')}
   }
 
   // Summary
-  console.log();
-  if (totalInstalled > 0) {
-    p.outro(pc.green(`Done! Installed ${totalInstalled} skill${totalInstalled === 1 ? '' : 's'}`));
-  } else if (totalSkipped > 0) {
-    p.outro(pc.yellow(`Skipped ${totalSkipped} existing skill${totalSkipped === 1 ? '' : 's'} - use --force to overwrite`));
+  if (jsonMode) {
+    outputJson();
   } else {
-    p.outro(pc.yellow('No skills installed'));
+    console.log();
+    if (totalInstalled > 0) {
+      p.outro(pc.green(`Done! Installed ${totalInstalled} skill${totalInstalled === 1 ? '' : 's'}`));
+    } else if (totalSkipped > 0) {
+      p.outro(pc.yellow(`Skipped ${totalSkipped} existing skill${totalSkipped === 1 ? '' : 's'} - use --force to overwrite`));
+    } else {
+      p.outro(pc.yellow('No skills installed'));
+    }
   }
 }
 
 async function selectInstallLocation(projectFlag: boolean, globalFlag: boolean): Promise<string> {
   // If flag specified, use it
   if (projectFlag) {
-    p.log.info(`Location: ${pc.cyan('Project')} ${pc.dim('(./')}${pc.dim(AGENTS[0].dir)}${pc.dim(')')}`);
+    if (!jsonMode) {
+      p.log.info(`Location: ${pc.cyan('Project')} ${pc.dim('(./')}${pc.dim(AGENTS[0].dir)}${pc.dim(')')}`);
+    }
     return process.cwd();
   }
   if (globalFlag) {
-    p.log.info(`Location: ${pc.cyan('Global')} ${pc.dim('(~/')}${pc.dim(AGENTS[0].dir)}${pc.dim(')')}`);
+    if (!jsonMode) {
+      p.log.info(`Location: ${pc.cyan('Global')} ${pc.dim('(~/')}${pc.dim(AGENTS[0].dir)}${pc.dim(')')}`);
+    }
     return homedir();
   }
 
-  // Non-TTY defaults to global
-  if (!process.stdin.isTTY) {
+  // Non-TTY or JSON mode defaults to global
+  if (!process.stdin.isTTY || jsonMode) {
     return homedir();
   }
 
@@ -393,7 +628,7 @@ async function selectInstallLocation(projectFlag: boolean, globalFlag: boolean):
 
   if (p.isCancel(location)) {
     p.cancel('Cancelled');
-    process.exit(0);
+    process.exit(EXIT_CANCELLED);
   }
 
   return location === 'project' ? process.cwd() : homedir();
@@ -403,7 +638,9 @@ async function selectAgents(agents: readonly Agent[], isLocal: boolean): Promise
   const pathPrefix = isLocal ? '.' : '~';
 
   // Show detected agents
-  p.log.info(`Detected ${pc.cyan(agents.length.toString())} agent${agents.length === 1 ? '' : 's'}: ${agents.map(a => a.name).join(', ')}`);
+  if (!jsonMode) {
+    p.log.info(`Detected ${pc.cyan(agents.length.toString())} agent${agents.length === 1 ? '' : 's'}: ${agents.map(a => a.name).join(', ')}`);
+  }
 
   const installAll = await p.confirm({
     message: 'Install to all detected agents?',
@@ -412,7 +649,7 @@ async function selectAgents(agents: readonly Agent[], isLocal: boolean): Promise
 
   if (p.isCancel(installAll)) {
     p.cancel('Cancelled');
-    process.exit(0);
+    process.exit(EXIT_CANCELLED);
   }
 
   if (installAll) {
@@ -434,7 +671,7 @@ async function selectAgents(agents: readonly Agent[], isLocal: boolean): Promise
 
   if (p.isCancel(selected)) {
     p.cancel('Cancelled');
-    process.exit(0);
+    process.exit(EXIT_CANCELLED);
   }
 
   return agents.filter(a => selected.includes(a.name));
@@ -447,21 +684,30 @@ type SkillMetadata = {
   description: string; // From frontmatter or empty
 };
 
-async function discoverSkillPaths(owner: string, repo: string): Promise<string[] | null> {
+async function discoverSkillPaths(owner: string, repo: string, installAll: boolean = false): Promise<string[] | null> {
   const skillPaths = await findAllSkillMdFiles(owner, repo);
 
   if (skillPaths.length === 0) {
-    p.log.error('No SKILL.md found in repository');
+    const errorMsg = `No ${SKILL_FILENAME} found in repository`;
+    if (jsonMode) {
+      addJsonError(errorMsg);
+    } else {
+      p.log.error(errorMsg);
+    }
     return null;
   }
 
   // Fetch frontmatter metadata for all skills in parallel
-  const s = p.spinner();
-  s.start('Fetching skill metadata...');
+  let spinner: ReturnType<typeof p.spinner> | null = null;
+  if (!jsonMode) {
+    spinner = p.spinner();
+    spinner.start('Fetching skill metadata...');
+  }
 
-  const metadataPromises = skillPaths.map(async (sp): Promise<SkillMetadata> => {
-    const skillDir = sp === 'SKILL.md' ? '.' : dirname(sp);
-    const folderName = sp === 'SKILL.md' ? repo : basename(skillDir);
+  // Fetch metadata with bounded concurrency (max 10 parallel requests)
+  const skills = await batchMap(skillPaths, async (sp): Promise<SkillMetadata> => {
+    const skillDir = sp === SKILL_FILENAME ? '.' : dirname(sp);
+    const folderName = sp === SKILL_FILENAME ? repo : basename(skillDir);
 
     // Fetch raw content to parse frontmatter
     const content = await fetchSkillMdContent(owner, repo, sp);
@@ -469,20 +715,26 @@ async function discoverSkillPaths(owner: string, repo: string): Promise<string[]
 
     return {
       path: sp,
-      dir: skillDir === '.' ? 'SKILL.md' : skillDir,
+      dir: skillDir === '.' ? SKILL_FILENAME : skillDir,
       name: frontmatter.name || folderName,
       description: frontmatter.description || '',
     };
-  });
+  }, 10);
 
-  const skills = await Promise.all(metadataPromises);
-  s.stop(`Found ${pc.cyan(skills.length.toString())} skill${skills.length === 1 ? '' : 's'}`);
+  if (spinner) {
+    spinner.stop(`Found ${pc.cyan(skills.length.toString())} skill${skills.length === 1 ? '' : 's'}`);
+  }
+
+  // Store found skills in JSON output
+  jsonOutput.skills_found = skills.map(s => s.name);
 
   if (skills.length === 1) {
     const skill = skills[0];
     const displayName = toTitleCase(skill.name);
     const desc = skill.description ? truncate(skill.description, 60) : '';
-    p.log.info(`${pc.bold(displayName)}${desc ? pc.dim(` - ${desc}`) : ''}`);
+    if (!jsonMode) {
+      p.log.info(`${pc.bold(displayName)}${desc ? pc.dim(` - ${desc}`) : ''}`);
+    }
     return [skill.dir];
   }
 
@@ -494,15 +746,28 @@ async function discoverSkillPaths(owner: string, repo: string): Promise<string[]
     hint: skill.description || undefined,
   }));
 
-  // Non-TTY: list skills and exit with guidance
-  if (!process.stdin.isTTY) {
-    console.log(`\nFound ${skills.length} skills in this repository:`);
-    for (const skill of skills) {
-      const displayName = toTitleCase(skill.name);
-      const desc = skill.description ? pc.dim(` - ${truncate(skill.description, 80)}`) : '';
-      console.log(`  - ${displayName}${desc}`);
+  // Non-TTY or JSON mode: require --all or --path for multiple skills
+  if (!process.stdin.isTTY || jsonMode) {
+    // If --all flag is set, install all skills
+    if (installAll) {
+      if (!jsonMode) {
+        console.log(`Installing all ${skills.length} skills`);
+      }
+      return skills.map(s => s.dir);
     }
-    console.error('\nMultiple skills found. Use --path to specify which one (non-interactive mode).');
+
+    // Otherwise, list skills and exit with guidance
+    if (jsonMode) {
+      addJsonError('Multiple skills found. Use --path or --all to specify which one(s).');
+    } else {
+      console.log(`\nFound ${skills.length} skills in this repository:`);
+      for (const skill of skills) {
+        const displayName = toTitleCase(skill.name);
+        const desc = skill.description ? pc.dim(` - ${truncate(skill.description, 80)}`) : '';
+        console.log(`  - ${displayName}${desc}`);
+      }
+      console.error('\nMultiple skills found. Use --path or --all to specify which one(s) (non-interactive mode).');
+    }
     return null;
   }
 
@@ -515,7 +780,7 @@ async function discoverSkillPaths(owner: string, repo: string): Promise<string[]
 
   if (p.isCancel(selected)) {
     p.cancel('Cancelled');
-    process.exit(0);
+    process.exit(EXIT_CANCELLED);
   }
 
   return selected;
@@ -526,6 +791,33 @@ type InstallResult = {
   skipped: number;
   failed: boolean;
 };
+
+/**
+ * SECURITY: Show warning and ask for user confirmation before installing.
+ * This mitigates supply chain attacks by making users acknowledge the source.
+ */
+async function confirmInstall(
+  owner: string,
+  repo: string,
+  skillName: string
+): Promise<boolean> {
+  console.log();
+  p.log.warn(pc.yellow('Skills can instruct AI agents to perform actions on your behalf.'));
+  console.log(pc.dim(`  Source: github.com/${owner}/${repo}`));
+  console.log(pc.dim('  Use --yes to skip this prompt for trusted sources.'));
+  console.log();
+
+  const proceed = await p.confirm({
+    message: `Install ${pc.bold(skillName)} from ${pc.cyan(`${owner}/${repo}`)}?`,
+    initialValue: true,
+  });
+
+  if (p.isCancel(proceed)) {
+    return false;
+  }
+
+  return proceed;
+}
 
 async function installSkill(
   owner: string,
@@ -540,53 +832,96 @@ async function installSkill(
   const isLocal = baseDir !== homedir();
   const pathPrefix = isLocal ? '.' : '~';
 
-  p.log.step(`Installing ${pc.bold(skillName)}`);
+  if (!jsonMode) {
+    p.log.step(`Installing ${pc.bold(skillName)}`);
+  }
 
   const tmpDir = join(homedir(), '.cache', 'skillfish', `${owner}-${repo}-${randomUUID()}`);
-  mkdirSync(tmpDir, { recursive: true });
+  mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
 
   try {
     // Download skill
-    const downloadPath = skillPath === 'SKILL.md' ? '' : skillPath;
+    const downloadPath = skillPath === SKILL_FILENAME ? '' : skillPath;
     const degitPath = downloadPath ? `${owner}/${repo}/${downloadPath}` : `${owner}/${repo}`;
 
-    const s = p.spinner();
-    s.start(`Downloading ${skillName}...`);
+    let spinner: ReturnType<typeof p.spinner> | null = null;
+    if (!jsonMode) {
+      spinner = p.spinner();
+      spinner.start(`Downloading ${skillName}...`);
+    }
 
     const emitter = degit(degitPath, { cache: false, force: true });
     await emitter.clone(tmpDir);
 
     // Validate download
-    const skillMdPath = join(tmpDir, 'SKILL.md');
+    const skillMdPath = join(tmpDir, SKILL_FILENAME);
     if (!existsSync(skillMdPath)) {
-      s.stop(pc.red('SKILL.md not found'));
-      console.error(`Error: SKILL.md not found in downloaded content. Path may be incorrect.`);
+      if (spinner) {
+        spinner.stop(pc.red(`${SKILL_FILENAME} not found`));
+      }
+      const errorMsg = `${SKILL_FILENAME} not found in downloaded content. Path may be incorrect.`;
+      if (jsonMode) {
+        addJsonError(errorMsg);
+      } else {
+        console.error(`Error: ${errorMsg}`);
+      }
       result.failed = true;
       return result;
     }
 
-    s.stop(pc.green('Downloaded'));
+    if (spinner) {
+      spinner.stop(pc.green('Downloaded'));
+    }
 
     // Copy to each installed agent
     for (const agent of agents) {
       const destDir = join(baseDir, agent.dir, skillName);
+      const displayPath = `${pathPrefix}/${agent.dir}/${skillName}`;
 
       if (existsSync(destDir) && !force) {
-        console.log(`  ${pc.yellow('●')} ${agent.name} ${pc.dim('(exists)')}`);
+        if (!jsonMode) {
+          console.log(`  ${pc.yellow('●')} ${agent.name} ${pc.dim('(exists)')}`);
+        }
+        jsonOutput.skipped.push({
+          skill: skillName,
+          agent: agent.name,
+          reason: 'Already exists (use --force to overwrite)',
+        });
         result.skipped++;
         continue;
       }
 
-      mkdirSync(join(baseDir, agent.dir), { recursive: true });
+      mkdirSync(join(baseDir, agent.dir), { recursive: true, mode: 0o700 });
       if (existsSync(destDir)) rmSync(destDir, { recursive: true });
       // Use safe copy to skip symlinks (security: prevents symlink attacks)
-      safeCopyDir(tmpDir, destDir);
-      console.log(`  ${pc.green('✓')} ${agent.name} ${pc.dim(`→ ${pathPrefix}/${agent.dir}/${skillName}`)}`);
+      const warnings = safeCopyDir(tmpDir, destDir);
+
+      if (!jsonMode) {
+        console.log(`  ${pc.green('✓')} ${agent.name} ${pc.dim(`→ ${displayPath}`)}`);
+      }
+
+      jsonOutput.installed.push({
+        skill: skillName,
+        agent: agent.name,
+        path: destDir,
+      });
+
+      // Include any warnings (e.g., skipped symlinks)
+      if (warnings.length > 0) {
+        for (const warning of warnings) {
+          jsonOutput.errors.push(`${skillName}: ${warning}`);
+        }
+      }
+
       result.installed++;
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(pc.red(`Error: ${message}`));
+    if (jsonMode) {
+      addJsonError(`Install failed: ${message}`);
+    } else {
+      console.error(pc.red(`Error: ${message}`));
+    }
     result.failed = true;
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -595,139 +930,122 @@ async function installSkill(
   return result;
 }
 
-function deriveSkillName(skillPath: string, repoName: string): string {
-  if (skillPath === 'SKILL.md' || skillPath === './SKILL.md') {
-    return repoName;
-  }
-
-  const normalized = skillPath.replace(/\/SKILL\.md$/i, '');
-  const name = basename(normalized);
-
-  if (!/^[\w.-]+$/.test(name)) {
-    return repoName;
-  }
-
-  return name;
-}
-
-/**
- * Convert kebab-case or snake_case to Title Case.
- * "skill-lookup" → "Skill Lookup"
- * "my_cool_skill" → "My Cool Skill"
- */
-function toTitleCase(str: string): string {
-  return str
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, char => char.toUpperCase());
-}
-
-/**
- * Truncate text to a maximum length, adding ellipsis if needed.
- */
-function truncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - 1).trim() + '…';
-}
-
-/**
- * Parse YAML frontmatter from SKILL.md content.
- * Extracts name and description fields with fallbacks.
- */
-function parseFrontmatter(content: string): { name?: string; description?: string } {
-  // Match frontmatter block: ---\n...\n---
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return {};
-
-  const yaml = match[1];
-
-  // Extract name (handles quoted and unquoted values)
-  const nameMatch = yaml.match(/^name:\s*["']?(.+?)["']?\s*$/m);
-  const name = nameMatch?.[1]?.trim();
-
-  // Extract description (handles quoted and unquoted values)
-  const descMatch = yaml.match(/^description:\s*["']?(.+?)["']?\s*$/m);
-  const description = descMatch?.[1]?.trim();
-
-  return { name, description };
-}
-
 /**
  * Fetch raw SKILL.md content from GitHub.
  * Uses raw.githubusercontent.com which is not rate-limited like the API.
+ * Tries both main and master branches in parallel for better performance.
  */
 async function fetchSkillMdContent(
   owner: string,
   repo: string,
-  path: string,
-  branch: string = 'main'
+  path: string
 ): Promise<string | null> {
-  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
+  const headers = { 'User-Agent': 'skillfish' };
 
-  try {
-    const res = await fetch(url, {
-      headers: { 'User-Agent': 'skillfish' },
-    });
+  // Try both branches in parallel
+  const results = await Promise.allSettled(
+    DEFAULT_BRANCHES.map(async branch => {
+      const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
+      const res = await fetchWithRetry(url, { headers }, 2);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.text();
+    })
+  );
 
-    if (!res.ok) {
-      // Try master branch if main fails
-      if (branch === 'main') {
-        return fetchSkillMdContent(owner, repo, path, 'master');
-      }
-      return null;
+  // Return first successful result
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      return result.value;
     }
-
-    return await res.text();
-  } catch {
-    return null;
   }
+
+  return null;
 }
 
+/**
+ * Find all SKILL.md files in a GitHub repository.
+ * Uses sequential branch checking to conserve API rate limit (60/hr unauthenticated).
+ */
 async function findAllSkillMdFiles(owner: string, repo: string): Promise<string[]> {
   const headers: Record<string, string> = { 'User-Agent': 'skillfish' };
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
   try {
-    const res = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/trees/main?recursive=1`,
-      { headers, signal: controller.signal }
-    );
+    // Try each branch sequentially to conserve rate limit
+    for (const branch of DEFAULT_BRANCHES) {
+      const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
 
-    if (!res.ok) {
-      // Check for rate limiting
-      if (res.status === 403) {
-        const remaining = res.headers.get('X-RateLimit-Remaining');
-        if (remaining === '0') {
-          console.error('GitHub API rate limit exceeded. Please try again later.');
+      try {
+        const res = await fetchWithRetry(url, { headers, signal: controller.signal });
+
+        // Check for rate limiting
+        if (res.status === 403) {
+          const remaining = res.headers.get('X-RateLimit-Remaining');
+          if (remaining === '0') {
+            const errorMsg = 'GitHub API rate limit exceeded. Please try again later.';
+            if (jsonMode) {
+              addJsonError(errorMsg);
+            } else {
+              console.error(errorMsg);
+            }
+            return [];
+          }
+        }
+
+        // 404 means branch doesn't exist, try next
+        if (res.status === 404) {
+          continue;
+        }
+
+        if (!res.ok) {
+          continue;
+        }
+
+        const rawData: unknown = await res.json();
+
+        if (!isGitTreeResponse(rawData)) {
+          const errorMsg = 'Unexpected response format from GitHub API.';
+          if (jsonMode) {
+            addJsonError(errorMsg);
+          } else {
+            console.error(errorMsg);
+          }
           return [];
         }
-      }
 
-      // Try 'master' branch if 'main' fails
-      const res2 = await fetch(
-        `https://api.github.com/repos/${owner}/${repo}/git/trees/master?recursive=1`,
-        { headers, signal: controller.signal }
-      );
-      if (!res2.ok) {
-        if (res2.status === 404) {
-          console.error('Repository not found. Check the owner/repo name.');
+        return extractSkillPaths(rawData, SKILL_FILENAME);
+      } catch (err) {
+        // If this is the last branch, let the error propagate
+        if (branch === DEFAULT_BRANCHES[DEFAULT_BRANCHES.length - 1]) {
+          throw err;
         }
-        return [];
+        // Otherwise try next branch
+        continue;
       }
-      const data = await res2.json() as { tree?: Array<{ path: string; type: string }> };
-      return (data.tree || [])
-        .filter(item => item.type === 'blob' && item.path.endsWith('SKILL.md'))
-        .map(item => item.path);
     }
 
-    const data = await res.json() as { tree?: Array<{ path: string; type: string }> };
-    return (data.tree || [])
-      .filter(item => item.type === 'blob' && item.path.endsWith('SKILL.md'))
-      .map(item => item.path);
+    // No branch found
+    const errorMsg = 'Repository not found. Check the owner/repo name.';
+    if (jsonMode) {
+      addJsonError(errorMsg);
+    } else {
+      console.error(errorMsg);
+    }
+    return [];
   } catch (err: unknown) {
+    let errorMsg: string;
     if (err instanceof Error && err.name === 'AbortError') {
-      console.error('Request timed out. Check your network connection.');
+      errorMsg = 'Request timed out. Check your network connection.';
+    } else {
+      errorMsg = `Network error: ${err instanceof Error ? err.message : 'unknown error'}`;
+    }
+
+    if (jsonMode) {
+      addJsonError(errorMsg);
+    } else {
+      console.error(errorMsg);
     }
     return [];
   } finally {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,4 @@
-const SUPABASE_URL = 'https://wulqksgnqhecytjqllyw.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Ind1bHFrc2ducWhlY3l0anFsbHl3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI3MTQyMzQsImV4cCI6MjA1ODI5MDIzNH0.wNKfhgboViKNBWDr1AFsguh8y5hL0tXFH6oaUI5BMS0';
+const TELEMETRY_URL = 'https://mcpmarket.com/api/telemetry';
 
 /**
  * Track a skill install. Fire-and-forget - never blocks or throws.
@@ -8,20 +7,18 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
  * if the CLI process exits immediately after calling. This is acceptable
  * for directional metrics (like npm download counts).
  *
- * @param github Full GitHub path matching the skills.github column (e.g., owner/repo/path/to/skill)
+ * @param github Full GitHub path (e.g., owner/repo/path/to/skill)
  */
 export function trackInstall(github: string): void {
   try {
     if (process.env.DO_NOT_TRACK === '1' || process.env.CI === 'true') return;
     if (!github || github.length > 500) return;
 
-    fetch(`${SUPABASE_URL}/rest/v1/rpc/increment_skill_install`, {
+    // POST with JSON body - fire and forget
+    fetch(TELEMETRY_URL, {
       method: 'POST',
-      headers: {
-        'apikey': SUPABASE_ANON_KEY,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ p_github: github }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ github }),
     }).catch(() => {});
   } catch {
     // Telemetry should never throw

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,179 @@
+/**
+ * Utility functions for skillfish CLI.
+ * These are pure functions extracted for testability.
+ */
+
+import { normalize, isAbsolute, basename } from 'path';
+
+/**
+ * Validates a path to prevent directory traversal attacks.
+ * Ensures path doesn't escape the intended directory.
+ */
+export function isValidPath(pathStr: string): boolean {
+  // Reject absolute paths
+  if (isAbsolute(pathStr)) return false;
+
+  // Normalize and check for directory traversal
+  const normalized = normalize(pathStr);
+  if (normalized.startsWith('..') || normalized.includes('/../')) return false;
+
+  // Only allow alphanumeric, dots, hyphens, underscores, and forward slashes
+  if (!/^[\w./-]+$/.test(pathStr)) return false;
+
+  // Reject paths that could be problematic
+  if (pathStr.includes('//') || pathStr.startsWith('/')) return false;
+
+  return true;
+}
+
+/**
+ * Type for GitHub tree API item.
+ */
+export type GitTreeItem = {
+  path: string;
+  type: string;
+  mode?: string;
+  sha?: string;
+  size?: number;
+  url?: string;
+};
+
+/**
+ * Type for GitHub tree API response.
+ */
+export type GitTreeResponse = {
+  tree?: GitTreeItem[];
+  sha?: string;
+  url?: string;
+  truncated?: boolean;
+};
+
+/**
+ * Type guard for GitHub tree API response.
+ * Validates the response structure at runtime.
+ */
+export function isGitTreeResponse(data: unknown): data is GitTreeResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+
+  // tree is optional, but if present must be an array
+  if ('tree' in obj && obj.tree !== undefined) {
+    if (!Array.isArray(obj.tree)) return false;
+    // Validate each item has required fields
+    for (const item of obj.tree) {
+      if (typeof item !== 'object' || item === null) return false;
+      const entry = item as Record<string, unknown>;
+      if (typeof entry.path !== 'string') return false;
+      if (typeof entry.type !== 'string') return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Parse YAML frontmatter from SKILL.md content.
+ * Extracts name and description fields with fallbacks.
+ */
+export function parseFrontmatter(content: string): { name?: string; description?: string } {
+  // Match frontmatter block: ---\n...\n---
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const yaml = match[1];
+
+  // Extract name (handles quoted and unquoted values)
+  const nameMatch = yaml.match(/^name:\s*["']?(.+?)["']?\s*$/m);
+  const name = nameMatch?.[1]?.trim();
+
+  // Extract description (handles quoted and unquoted values)
+  const descMatch = yaml.match(/^description:\s*["']?(.+?)["']?\s*$/m);
+  const description = descMatch?.[1]?.trim();
+
+  return { name, description };
+}
+
+/**
+ * Derive skill name from path and repo name.
+ */
+export function deriveSkillName(skillPath: string, repoName: string): string {
+  if (skillPath === 'SKILL.md' || skillPath === './SKILL.md') {
+    return repoName;
+  }
+
+  const normalized = skillPath.replace(/\/SKILL\.md$/i, '');
+  const name = basename(normalized);
+
+  if (!/^[\w.-]+$/.test(name)) {
+    return repoName;
+  }
+
+  return name;
+}
+
+/**
+ * Convert kebab-case or snake_case to Title Case.
+ * "skill-lookup" → "Skill Lookup"
+ * "my_cool_skill" → "My Cool Skill"
+ */
+export function toTitleCase(str: string): string {
+  return str
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+/**
+ * Truncate text to a maximum length, adding ellipsis if needed.
+ */
+export function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 1).trim() + '…';
+}
+
+/**
+ * Extract SKILL.md paths from validated GitHub tree response.
+ */
+export function extractSkillPaths(data: GitTreeResponse, skillFilename: string = 'SKILL.md'): string[] {
+  if (!data.tree) return [];
+  return data.tree
+    .filter(item => item.type === 'blob' && item.path.endsWith(skillFilename))
+    .map(item => item.path);
+}
+
+/**
+ * Sleep for a specified duration.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Process items with bounded concurrency.
+ * Prevents overwhelming resources with unbounded parallel requests.
+ *
+ * @param items - Items to process
+ * @param fn - Async function to apply to each item
+ * @param concurrency - Maximum concurrent operations (default: 10)
+ */
+export async function batchMap<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number = 10
+): Promise<R[]> {
+  const results: R[] = [];
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const currentIndex = index++;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
+  }
+
+  // Start workers up to concurrency limit
+  const workers = Array(Math.min(concurrency, items.length))
+    .fill(null)
+    .map(() => worker());
+
+  await Promise.all(workers);
+  return results;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['dist/**/*', 'node_modules/**/*'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `add` and `list` subcommands for clearer CLI structure
- Implements JSON output mode (`--json`) for automation
- Adds `--all` flag for non-interactive multi-skill installs and `--yes` to skip confirmation
- Extracts utilities to testable module with comprehensive unit tests
- Improves security with confirmation prompts, strict file permissions, and TOCTOU mitigation

## Test plan

- [ ] Run `npm test` to verify unit tests pass
- [ ] Test `skillfish add owner/repo` interactive flow
- [ ] Test `skillfish add owner/repo --json` output format
- [ ] Test `skillfish list --global` displays installed skills

🤖 Generated with [Claude Code](https://claude.ai/code)