### PR TITLE
Fix telemetry not sending to API endpoint

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -213,6 +213,7 @@ Examples:
     // Install each selected skill
     let totalInstalled = 0;
     let totalSkipped = 0;
+    const telemetryPromises: Promise<void>[] = [];
 
     // SECURITY: Ask for confirmation before installation (unless --yes is used)
     // Single confirmation for all selected skills
@@ -293,13 +294,18 @@ Examples:
       totalInstalled += result.installed.length;
       totalSkipped += result.skipped.length;
 
-      // Track successful installs (fire-and-forget telemetry)
+      // Track successful installs (telemetry with timeout)
       if (result.installed.length > 0) {
         // Construct github value to match skills.github column format: owner/repo/path/to/skill
         const skillDir = skillPath.replace(/\/?SKILL\.md$/i, '').replace(/^\.?\/?/, '');
         const github = skillDir ? `${owner}/${repo}/${skillDir}` : `${owner}/${repo}`;
-        trackInstall(github);
+        telemetryPromises.push(trackInstall(github));
       }
+    }
+
+    // Wait for telemetry to complete (with timeout built into trackInstall)
+    if (telemetryPromises.length > 0) {
+      await Promise.all(telemetryPromises);
     }
 
     // Summary

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,26 +1,38 @@
 const TELEMETRY_URL = 'https://mcpmarket.com/api/telemetry';
 
+/** Timeout for telemetry requests (ms) */
+const TELEMETRY_TIMEOUT = 2000;
+
 /**
- * Track a skill install. Fire-and-forget - never blocks or throws.
- *
- * NOTE: Due to Node.js event loop behavior, this request may not complete
- * if the CLI process exits immediately after calling. This is acceptable
- * for directional metrics (like npm download counts).
+ * Track a skill install. Returns a promise that resolves when the request
+ * completes (or times out). Never rejects.
  *
  * @param github Full GitHub path (e.g., owner/repo/path/to/skill)
+ * @returns Promise that resolves when telemetry is sent (or times out)
  */
-export function trackInstall(github: string): void {
+export function trackInstall(github: string): Promise<void> {
   try {
-    if (process.env.DO_NOT_TRACK === '1' || process.env.CI === 'true') return;
-    if (!github || github.length > 500) return;
+    if (process.env.DO_NOT_TRACK === '1' || process.env.CI === 'true') {
+      return Promise.resolve();
+    }
+    if (!github || github.length > 500) {
+      return Promise.resolve();
+    }
 
-    // POST with JSON body - fire and forget
-    fetch(TELEMETRY_URL, {
+    // Race between the fetch and a timeout to ensure we don't block the CLI
+    const fetchPromise = fetch(TELEMETRY_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ github }),
-    }).catch(() => {});
+    }).then(() => {}).catch(() => {});
+
+    const timeoutPromise = new Promise<void>((resolve) => {
+      setTimeout(resolve, TELEMETRY_TIMEOUT);
+    });
+
+    return Promise.race([fetchPromise, timeoutPromise]);
   } catch {
     // Telemetry should never throw
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
The telemetry was using fire-and-forget fetch calls, but process.exit() was being called immediately after, causing Node.js to abort the HTTP requests before they could complete.

Changes:
- Make trackInstall() return a Promise that resolves when the request completes or times out (2s max)
- Collect telemetry promises and await them before exiting