### PR TITLE
fix(ux): truncate multiselect hints to reduce visual noise

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -633,11 +633,11 @@ async function discoverSkillPaths(
   }
 
   // Build options for selection with frontmatter metadata
-  // Title in label, description in hint (shows on focus)
+  // Title in label, truncated description in hint (keeps UI clean)
   const optionsList = skills.map((skill) => ({
     value: skill.dir,
     label: pc.bold(toTitleCase(skill.name)),
-    hint: skill.description || undefined,
+    hint: skill.description ? truncate(skill.description, 70) : undefined,
   }));
 
   // Non-TTY or JSON mode: require --all or --path for multiple skills


### PR DESCRIPTION
## Summary
- Truncate skill description hints to 70 characters in multiselect prompts
- Fixes visual clutter when multiple skills are selected (each selection was showing full multi-line descriptions)

## Problem
`@clack/prompts` multiselect shows hints for all selected items. Long descriptions cause visual noise:

```
Select skills to install
│  ◼ Claude Opus 4 5 Migration (Migrate prompts and code from Claude Sonnet 4.0,
Sonnet 4.5, or Opus 4.1 to Opus 4.5. Use when the user wants to update their
codebase, prompts, or API calls to use Opus 4.5. Handles model string updates
and prompt adjustments for known Opus 4.5 behavioral differences. Does NOT
migrate Haiku 4.5.)
│  ◻ Frontend Design
```

## Solution
Truncate hints to ~70 chars so each option stays on one line:

```
Select skills to install
│  ◼ Claude Opus 4 5 Migration (Migrate prompts and code from Claude Sonnet 4…)
│  ◻ Frontend Design
```

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm test` passes (126 tests)
- [x] Manual test with `skillfish add` on a repo with multiple skills

🤖 Generated with [Claude Code](https://claude.ai/code)