### PR TITLE
fix(ux): remove multiselect hints to fix rendering bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillfish",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillfish",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "AGPL-3.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillfish",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Install AI agent skills from GitHub with a single command",
   "type": "module",
   "bin": {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -633,11 +633,10 @@ async function discoverSkillPaths(
   }
 
   // Build options for selection with frontmatter metadata
-  // Title in label, truncated description in hint (keeps UI clean)
+  // No hints - @clack/prompts has rendering issues with long option lists
   const optionsList = skills.map((skill) => ({
     value: skill.dir,
-    label: pc.bold(toTitleCase(skill.name)),
-    hint: skill.description ? truncate(skill.description, 70) : undefined,
+    label: toTitleCase(skill.name),
   }));
 
   // Non-TTY or JSON mode: require --all or --path for multiple skills


### PR DESCRIPTION
## Summary
- Remove hints from multiselect options to fix duplicate row rendering bug

## Problem
`@clack/prompts` has rendering issues when hints are used on long option lists, causing each item to appear twice - once with hint, once without.

## Solution
Remove hints entirely. The skill names are descriptive enough on their own.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (126 tests)
- [x] Manual test confirms clean rendering

🤖 Generated with [Claude Code](https://claude.ai/code)