### PR TITLE
feat(auth): add login, logout, and whoami commands

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isValidTokenFormat,
+  getTokenPrefix,
+  getConfigDir,
+  getCredentialsPath,
+} from '../lib/auth.js';
+
+describe('isValidTokenFormat', () => {
+  it('accepts valid token format', () => {
+    // 32 character suffix (minimum)
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(32))).toBe(true);
+    // 64 character suffix
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(64))).toBe(true);
+    // 128 character suffix (maximum)
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(128))).toBe(true);
+    // Mixed alphanumeric (32 chars: abc123DEF456ghi789JKL012mnopqrst)
+    expect(isValidTokenFormat('sk_user_abc123DEF456ghi789JKL012mnopqrst')).toBe(true);
+  });
+
+  it('rejects tokens without correct prefix', () => {
+    expect(isValidTokenFormat('sk_' + 'a'.repeat(32))).toBe(false);
+    expect(isValidTokenFormat('token_' + 'a'.repeat(32))).toBe(false);
+    expect(isValidTokenFormat('a'.repeat(40))).toBe(false);
+    expect(isValidTokenFormat('SK_USER_' + 'a'.repeat(32))).toBe(false); // case sensitive
+  });
+
+  it('rejects tokens with invalid suffix length', () => {
+    // Too short (31 chars)
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(31))).toBe(false);
+    // Too long (129 chars)
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(129))).toBe(false);
+  });
+
+  it('rejects tokens with invalid characters', () => {
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(31) + '!')).toBe(false);
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(31) + '-')).toBe(false);
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(31) + '_')).toBe(false);
+    expect(isValidTokenFormat('sk_user_' + 'a'.repeat(31) + ' ')).toBe(false);
+  });
+
+  it('rejects empty or whitespace tokens', () => {
+    expect(isValidTokenFormat('')).toBe(false);
+    expect(isValidTokenFormat('   ')).toBe(false);
+    expect(isValidTokenFormat('sk_user_')).toBe(false);
+  });
+});
+
+describe('getTokenPrefix', () => {
+  it('returns the expected prefix', () => {
+    expect(getTokenPrefix()).toBe('sk_user_');
+  });
+});
+
+describe('getConfigDir', () => {
+  const originalPlatform = process.platform;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    process.env = originalEnv;
+  });
+
+  it('uses XDG_CONFIG_HOME on Linux/macOS when set', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.XDG_CONFIG_HOME = '/custom/config';
+
+    // Re-import to pick up new env
+    // Note: Since getConfigDir reads env at call time, we can test directly
+    const result = getConfigDir();
+    // On macOS running tests, it will use the actual platform
+    // This test verifies the function structure
+    expect(typeof result).toBe('string');
+    expect(result.endsWith('skillfish')).toBe(true);
+  });
+
+  it('uses ~/.config on Linux/macOS when XDG_CONFIG_HOME not set', () => {
+    delete process.env.XDG_CONFIG_HOME;
+
+    const result = getConfigDir();
+    expect(typeof result).toBe('string');
+    expect(result.endsWith('skillfish')).toBe(true);
+  });
+
+  it('returns path ending with skillfish', () => {
+    const result = getConfigDir();
+    expect(result.endsWith('skillfish')).toBe(true);
+  });
+});
+
+describe('getCredentialsPath', () => {
+  it('returns path to credentials.json', () => {
+    const result = getCredentialsPath();
+    expect(result.endsWith('credentials.json')).toBe(true);
+    expect(result.includes('skillfish')).toBe(true);
+  });
+});

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,188 @@
+/**
+ * `skillfish login` command - Authenticate with skillfish.io.
+ */
+
+import { Command } from 'commander';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { printBanner } from '../lib/banner.js';
+import {
+  getToken,
+  storeToken,
+  validateToken,
+  isValidTokenFormat,
+  getTokenPrefix,
+} from '../lib/auth.js';
+import { isTTY, isInputTTY, type LoginJsonOutput } from '../utils.js';
+import { EXIT_CODES, type ExitCode } from '../lib/constants.js';
+
+// === Types ===
+
+interface LoginCommandOptions {
+  token?: string;
+}
+
+// === Command Definition ===
+
+export const loginCommand = new Command('login')
+  .description('Authenticate with skillfish.io')
+  .option('-t, --token <token>', 'API token (for CI/automation)')
+  .helpOption('-h, --help', 'Display help for command')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ skillfish login                  Interactive token prompt
+  $ skillfish login --token sk_...   Direct token input (CI/automation)
+  $ SKILLFISH_TOKEN=sk_... skillfish whoami   Use environment variable`,
+  )
+  .action(async (options: LoginCommandOptions, command: Command) => {
+    const jsonMode = command.parent?.opts().json ?? false;
+    const version = command.parent?.opts().version ?? '0.0.0';
+
+    const jsonOutput: LoginJsonOutput = {
+      success: true,
+      errors: [],
+    };
+
+    function addError(message: string): void {
+      jsonOutput.errors.push(message);
+      jsonOutput.success = false;
+    }
+
+    function outputJsonAndExit(exitCode: number): never {
+      jsonOutput.exit_code = exitCode;
+      console.log(JSON.stringify(jsonOutput, null, 2));
+      process.exit(exitCode);
+    }
+
+    function exitWithError(message: string, exitCode: ExitCode, useClackLog = false): never {
+      if (jsonMode) {
+        addError(message);
+        outputJsonAndExit(exitCode);
+      }
+      if (useClackLog) {
+        p.log.error(message);
+      } else {
+        console.error(message);
+      }
+      process.exit(exitCode);
+    }
+
+    // Show banner and intro (TTY only, not in JSON mode)
+    if (isTTY() && !jsonMode) {
+      printBanner();
+      p.intro(`${pc.bgCyan(pc.black(' skillfish '))} ${pc.dim(`v${version}`)}`);
+    }
+
+    const tokenArg = options.token?.trim() ?? null;
+
+    // Non-TTY without --token: error
+    if (!tokenArg && !isInputTTY()) {
+      exitWithError(
+        'Token required. Use --token or set SKILLFISH_TOKEN environment variable.',
+        EXIT_CODES.INVALID_ARGS,
+      );
+    }
+
+    let token: string;
+
+    if (tokenArg) {
+      // Direct token input (--token flag)
+      token = tokenArg;
+    } else {
+      // Interactive mode - check if already logged in
+      const existingToken = getToken();
+      if (existingToken) {
+        const overwrite = await p.confirm({
+          message: 'Already logged in. Overwrite existing credentials?',
+          initialValue: false,
+        });
+
+        if (p.isCancel(overwrite)) {
+          p.cancel('Cancelled');
+          process.exit(EXIT_CODES.SUCCESS);
+        }
+
+        if (!overwrite) {
+          p.outro(pc.dim('Keeping existing credentials'));
+          process.exit(EXIT_CODES.SUCCESS);
+        }
+      }
+
+      // Prompt for token
+      if (!jsonMode) {
+        p.log.info(pc.dim(`Get your token from ${pc.cyan('https://skill.fish/settings/tokens')}`));
+      }
+
+      const tokenInput = await p.password({
+        message: 'Enter your API token',
+        mask: '*',
+      });
+
+      if (p.isCancel(tokenInput)) {
+        p.cancel('Cancelled');
+        process.exit(EXIT_CODES.SUCCESS);
+      }
+
+      token = (tokenInput as string).trim();
+    }
+
+    // Validate token format locally
+    if (!isValidTokenFormat(token)) {
+      exitWithError(
+        `Invalid token format. Token must start with '${getTokenPrefix()}'. Get your token from https://skill.fish/settings/tokens`,
+        EXIT_CODES.INVALID_ARGS,
+        !tokenArg, // Use clack log for interactive mode
+      );
+    }
+
+    // Validate token with API
+    let spinner: ReturnType<typeof p.spinner> | null = null;
+    if (!jsonMode) {
+      spinner = p.spinner();
+      spinner.start('Validating token...');
+    }
+
+    const result = await validateToken(token);
+
+    if (!result.valid) {
+      if (spinner) {
+        spinner.stop(pc.red('Validation failed'));
+      }
+
+      const exitCode =
+        result.error === 'network_error' ? EXIT_CODES.NETWORK_ERROR : EXIT_CODES.INVALID_ARGS;
+
+      exitWithError(result.message, exitCode, !tokenArg);
+    }
+
+    // Store token
+    try {
+      await storeToken(token);
+    } catch (err) {
+      if (spinner) {
+        spinner.stop(pc.red('Failed to store token'));
+      }
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      exitWithError(`Failed to store credentials: ${message}`, EXIT_CODES.GENERAL_ERROR, !tokenArg);
+    }
+
+    if (spinner) {
+      spinner.stop(pc.green('Logged in'));
+    }
+
+    // Success output
+    jsonOutput.user = result.user;
+    jsonOutput.email = result.email;
+
+    if (jsonMode) {
+      outputJsonAndExit(EXIT_CODES.SUCCESS);
+    }
+
+    p.log.success(
+      `Logged in as ${pc.bold(result.user)}${result.email ? ` (${result.email})` : ''}`,
+    );
+    p.outro(pc.dim('Credentials saved'));
+    process.exit(EXIT_CODES.SUCCESS);
+  });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,69 @@
+/**
+ * `skillfish logout` command - Remove stored authentication credentials.
+ */
+
+import { Command } from 'commander';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { printBanner } from '../lib/banner.js';
+import { clearToken, isEnvTokenSet } from '../lib/auth.js';
+import { isTTY, type LogoutJsonOutput } from '../utils.js';
+import { EXIT_CODES } from '../lib/constants.js';
+
+// === Types ===
+
+// No command-specific options for logout
+
+// === Command Definition ===
+
+export const logoutCommand = new Command('logout')
+  .description('Remove stored authentication credentials')
+  .helpOption('-h, --help', 'Display help for command')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ skillfish logout   Remove stored credentials`,
+  )
+  .action(async (_options: Record<string, never>, command: Command) => {
+    const jsonMode = command.parent?.opts().json ?? false;
+    const version = command.parent?.opts().version ?? '0.0.0';
+
+    const jsonOutput: LogoutJsonOutput = {
+      success: true,
+      errors: [],
+    };
+
+    function outputJsonAndExit(exitCode: number): never {
+      jsonOutput.exit_code = exitCode;
+      console.log(JSON.stringify(jsonOutput, null, 2));
+      process.exit(exitCode);
+    }
+
+    // Show banner and intro (TTY only, not in JSON mode)
+    if (isTTY() && !jsonMode) {
+      printBanner();
+      p.intro(`${pc.bgCyan(pc.black(' skillfish '))} ${pc.dim(`v${version}`)}`);
+    }
+
+    // Clear stored credentials
+    const wasLoggedIn = await clearToken();
+
+    // Warn if environment variable is still set (TTY only)
+    if (isTTY() && !jsonMode && isEnvTokenSet()) {
+      p.log.warn(pc.yellow('Note: SKILLFISH_TOKEN environment variable is still set'));
+    }
+
+    if (jsonMode) {
+      outputJsonAndExit(EXIT_CODES.SUCCESS);
+    }
+
+    if (wasLoggedIn) {
+      p.log.success('Logged out');
+    } else {
+      p.log.info('Already logged out');
+    }
+
+    p.outro(pc.dim('Credentials removed'));
+    process.exit(EXIT_CODES.SUCCESS);
+  });

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,132 @@
+/**
+ * `skillfish whoami` command - Display the currently authenticated user.
+ */
+
+import { Command } from 'commander';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { printBanner } from '../lib/banner.js';
+import { getToken, validateToken, clearToken } from '../lib/auth.js';
+import { isTTY, type WhoamiJsonOutput } from '../utils.js';
+import { EXIT_CODES, type ExitCode } from '../lib/constants.js';
+
+// === Types ===
+
+// No command-specific options for whoami
+
+// === Command Definition ===
+
+export const whoamiCommand = new Command('whoami')
+  .description('Display the currently authenticated user')
+  .helpOption('-h, --help', 'Display help for command')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ skillfish whoami   Show current user`,
+  )
+  .action(async (_options: Record<string, never>, command: Command) => {
+    const jsonMode = command.parent?.opts().json ?? false;
+    const version = command.parent?.opts().version ?? '0.0.0';
+
+    const jsonOutput: WhoamiJsonOutput = {
+      success: true,
+      logged_in: false,
+      errors: [],
+    };
+
+    function addError(message: string): void {
+      jsonOutput.errors.push(message);
+      jsonOutput.success = false;
+    }
+
+    function outputJsonAndExit(exitCode: number): never {
+      jsonOutput.exit_code = exitCode;
+      console.log(JSON.stringify(jsonOutput, null, 2));
+      process.exit(exitCode);
+    }
+
+    function exitWithError(message: string, exitCode: ExitCode, useClackLog = false): never {
+      if (jsonMode) {
+        addError(message);
+        outputJsonAndExit(exitCode);
+      }
+      if (useClackLog) {
+        p.log.error(message);
+      } else {
+        console.error(message);
+      }
+      process.exit(exitCode);
+    }
+
+    // Show banner and intro (TTY only, not in JSON mode)
+    if (isTTY() && !jsonMode) {
+      printBanner();
+      p.intro(`${pc.bgCyan(pc.black(' skillfish '))} ${pc.dim(`v${version}`)}`);
+    }
+
+    // Get token (env var or file)
+    const tokenInfo = getToken();
+
+    if (!tokenInfo) {
+      // Not logged in - not an error
+      if (jsonMode) {
+        outputJsonAndExit(EXIT_CODES.SUCCESS);
+      }
+
+      p.log.info("Not logged in. Run 'skillfish login' to authenticate.");
+      p.outro(pc.dim('https://skill.fish/settings/tokens'));
+      process.exit(EXIT_CODES.SUCCESS);
+    }
+
+    // Validate token with API
+    let spinner: ReturnType<typeof p.spinner> | null = null;
+    if (!jsonMode) {
+      spinner = p.spinner();
+      spinner.start('Fetching user info...');
+    }
+
+    const result = await validateToken(tokenInfo.token);
+
+    if (!result.valid) {
+      if (spinner) {
+        spinner.stop(pc.red('Failed'));
+      }
+
+      // If token is invalid/expired and stored in file, clear it
+      if (result.error !== 'network_error' && tokenInfo.source === 'file') {
+        await clearToken();
+        if (!jsonMode) {
+          p.log.warn(pc.dim('Cleared invalid stored credentials'));
+        }
+      }
+
+      const exitCode =
+        result.error === 'network_error' ? EXIT_CODES.NETWORK_ERROR : EXIT_CODES.INVALID_ARGS;
+
+      exitWithError(result.message, exitCode, true);
+    }
+
+    if (spinner) {
+      spinner.stop(pc.green('Authenticated'));
+    }
+
+    // Success
+    jsonOutput.logged_in = true;
+    jsonOutput.user = result.user;
+    jsonOutput.email = result.email;
+    jsonOutput.token_source = tokenInfo.source;
+
+    if (jsonMode) {
+      outputJsonAndExit(EXIT_CODES.SUCCESS);
+    }
+
+    p.log.success(
+      `Logged in as ${pc.bold(result.user)}${result.email ? ` (${result.email})` : ''}`,
+    );
+
+    const sourceLabel = tokenInfo.source === 'env' ? 'environment variable' : 'credentials file';
+    p.outro(pc.dim(`Token source: ${sourceLabel}`));
+
+    process.exit(EXIT_CODES.SUCCESS);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,13 @@ import { bundleCommand } from './commands/bundle.js';
 import { initCommand } from './commands/init.js';
 import { installCommand } from './commands/install.js';
 import { listCommand } from './commands/list.js';
+import { loginCommand } from './commands/login.js';
+import { logoutCommand } from './commands/logout.js';
 import { removeCommand } from './commands/remove.js';
 import { searchCommand } from './commands/search.js';
 import { updateCommand } from './commands/update.js';
 import { submitCommand } from './commands/submit.js';
+import { whoamiCommand } from './commands/whoami.js';
 
 // Read version from package.json (single source of truth)
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -91,10 +94,13 @@ program.addCommand(bundleCommand);
 program.addCommand(initCommand);
 program.addCommand(installCommand);
 program.addCommand(listCommand);
+program.addCommand(loginCommand);
+program.addCommand(logoutCommand);
 program.addCommand(removeCommand);
 program.addCommand(searchCommand);
 program.addCommand(updateCommand);
 program.addCommand(submitCommand);
+program.addCommand(whoamiCommand);
 
 // Propagate help styling to all subcommands (must run after all addCommand() calls)
 for (const cmd of program.commands) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,314 @@
+/**
+ * Authentication utilities for skillfish CLI.
+ *
+ * Handles token storage, retrieval, and validation for the skillfish.io API.
+ * Follows XDG Base Directory specification for config file locations.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { fetchWithRetry } from './http.js';
+
+// === Constants ===
+
+/** Environment variable for token override */
+const TOKEN_ENV_VAR = 'SKILLFISH_TOKEN';
+
+/** Token prefix for validation */
+const TOKEN_PREFIX = 'sk_user_';
+
+/** Token format regex: sk_user_ followed by 32-128 alphanumeric characters */
+const TOKEN_PATTERN = /^sk_user_[a-zA-Z0-9]{32,128}$/;
+
+/** API endpoint for token validation */
+const API_BASE_URL = 'https://skill.fish/api/v1';
+
+/** File permissions: owner read/write only */
+const FILE_MODE = 0o600;
+
+/** Directory permissions: owner only */
+const DIR_MODE = 0o700;
+
+// === Types ===
+
+/** Result of token validation against the API */
+export type TokenValidationResult =
+  | { valid: true; user: string; email: string }
+  | { valid: false; error: 'invalid_token' | 'expired' | 'network_error'; message: string };
+
+/** Source of the token (environment variable or file) */
+export type TokenSource = 'env' | 'file';
+
+/** Token with its source */
+export interface TokenInfo {
+  token: string;
+  source: TokenSource;
+}
+
+/** Credentials file schema */
+interface Credentials {
+  token: string;
+}
+
+// === Error Classes ===
+
+/**
+ * Error thrown for authentication-related failures.
+ */
+export class AuthenticationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthenticationError';
+  }
+}
+
+// === Path Functions ===
+
+/**
+ * Get XDG-compliant config directory for skillfish.
+ * - Linux/macOS: ~/.config/skillfish (or $XDG_CONFIG_HOME/skillfish)
+ * - Windows: %APPDATA%\skillfish
+ */
+export function getConfigDir(): string {
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA ?? homedir(), 'skillfish');
+  }
+  return join(process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config'), 'skillfish');
+}
+
+/**
+ * Get path to the credentials file.
+ */
+export function getCredentialsPath(): string {
+  return join(getConfigDir(), 'credentials.json');
+}
+
+// === Token Operations ===
+
+/**
+ * Get the current token, checking environment variable first.
+ * @returns Token info with source, or null if not authenticated
+ */
+export function getToken(): TokenInfo | null {
+  // Environment variable takes precedence
+  const envToken = process.env[TOKEN_ENV_VAR];
+  if (envToken) {
+    return { token: envToken, source: 'env' };
+  }
+
+  // Fall back to stored credentials
+  const storedToken = readStoredToken();
+  if (storedToken) {
+    return { token: storedToken, source: 'file' };
+  }
+
+  return null;
+}
+
+/**
+ * Read token from the credentials file.
+ * @returns Token string or null if not found/invalid
+ */
+function readStoredToken(): string | null {
+  const credentialsPath = getCredentialsPath();
+
+  if (!existsSync(credentialsPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(credentialsPath, 'utf-8');
+    const data = JSON.parse(content) as unknown;
+
+    if (!isValidCredentials(data)) {
+      return null;
+    }
+
+    return data.token;
+  } catch {
+    // JSON parse error or file read error
+    return null;
+  }
+}
+
+/**
+ * Store a token in the credentials file.
+ * Creates the config directory if it doesn't exist.
+ * Uses atomic write (temp file + rename) to prevent corruption.
+ *
+ * @param token - The token to store
+ * @throws Error if write fails
+ */
+export async function storeToken(token: string): Promise<void> {
+  const configDir = getConfigDir();
+  const credentialsPath = getCredentialsPath();
+  const tempPath = join(configDir, `.credentials.json.tmp.${process.pid}`);
+
+  // Ensure config directory exists with secure permissions
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true, mode: DIR_MODE });
+  }
+
+  const credentials: Credentials = { token };
+  const content = JSON.stringify(credentials, null, 2);
+
+  try {
+    // Write to temp file with secure permissions
+    writeFileSync(tempPath, content, { encoding: 'utf-8', mode: FILE_MODE });
+    // Atomic rename
+    renameSync(tempPath, credentialsPath);
+  } catch (err) {
+    // Clean up temp file on failure
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove stored credentials.
+ * @returns true if credentials were removed, false if they didn't exist
+ */
+export async function clearToken(): Promise<boolean> {
+  const credentialsPath = getCredentialsPath();
+
+  if (!existsSync(credentialsPath)) {
+    return false;
+  }
+
+  try {
+    unlinkSync(credentialsPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if environment variable is set (for logout warning).
+ */
+export function isEnvTokenSet(): boolean {
+  return !!process.env[TOKEN_ENV_VAR];
+}
+
+// === Token Validation ===
+
+/**
+ * Validate token format locally.
+ * @param token - Token to validate
+ * @returns true if format is valid
+ */
+export function isValidTokenFormat(token: string): boolean {
+  return TOKEN_PATTERN.test(token);
+}
+
+/**
+ * Get the expected token prefix for error messages.
+ */
+export function getTokenPrefix(): string {
+  return TOKEN_PREFIX;
+}
+
+/**
+ * Validate a token against the API.
+ * @param token - Token to validate
+ * @returns Validation result with user info or error
+ */
+export async function validateToken(token: string): Promise<TokenValidationResult> {
+  try {
+    const response = await fetchWithRetry(`${API_BASE_URL}/me`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as unknown;
+
+      // Validate response structure
+      if (isValidUserResponse(data)) {
+        return {
+          valid: true,
+          user: data.username ?? data.name ?? 'unknown',
+          email: data.email ?? '',
+        };
+      }
+
+      return {
+        valid: false,
+        error: 'invalid_token',
+        message: 'Invalid response from API',
+      };
+    }
+
+    // Handle specific error codes
+    if (response.status === 401) {
+      return {
+        valid: false,
+        error: 'invalid_token',
+        message: 'Invalid or expired token',
+      };
+    }
+
+    if (response.status === 403) {
+      return {
+        valid: false,
+        error: 'expired',
+        message: 'Token has been revoked',
+      };
+    }
+
+    return {
+      valid: false,
+      error: 'network_error',
+      message: `API returned status ${response.status}`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return {
+      valid: false,
+      error: 'network_error',
+      message: `Network error: ${message}`,
+    };
+  }
+}
+
+// === Type Guards ===
+
+/**
+ * Type guard for credentials file structure.
+ */
+function isValidCredentials(data: unknown): data is Credentials {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'token' in data &&
+    typeof (data as Record<string, unknown>).token === 'string'
+  );
+}
+
+/**
+ * Type guard for API user response.
+ * Accepts responses with username or name field, plus optional email.
+ */
+function isValidUserResponse(
+  data: unknown,
+): data is { username?: string; name?: string; email?: string } {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+  // Must have either username or name
+  const hasIdentifier =
+    (typeof obj.username === 'string' && obj.username.length > 0) ||
+    (typeof obj.name === 'string' && obj.name.length > 0);
+  // Email is optional but must be string if present
+  const emailValid = obj.email === undefined || typeof obj.email === 'string';
+  return hasIdentifier && emailValid;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -316,6 +316,30 @@ export interface InstallJsonOutput extends BaseJsonOutput {
   conflicts: { skill: string; reason: string }[];
 }
 
+/**
+ * JSON output for the `login` command.
+ */
+export interface LoginJsonOutput extends BaseJsonOutput {
+  user?: string;
+  email?: string;
+}
+
+/**
+ * JSON output for the `logout` command.
+ * Uses BaseJsonOutput directly (success, exit_code, errors).
+ */
+export type LogoutJsonOutput = BaseJsonOutput;
+
+/**
+ * JSON output for the `whoami` command.
+ */
+export interface WhoamiJsonOutput extends BaseJsonOutput {
+  logged_in: boolean;
+  user?: string;
+  email?: string;
+  token_source?: 'env' | 'file';
+}
+
 /** @deprecated Use AddJsonOutput instead */
 export type JsonOutput = AddJsonOutput;
 


### PR DESCRIPTION
## Summary

Add token-based authentication to skillfish CLI, enabling users to authenticate with the commercial skill.fish API using personal API tokens. This follows industry-standard patterns used by GitHub CLI, Vercel CLI, and npm.

**New Commands:**
- `skillfish login` - Interactive token prompt (or `--token` flag for CI)
- `skillfish logout` - Remove stored credentials
- `skillfish whoami` - Display current authenticated user and token source

## Implementation Details

- **XDG-compliant storage:** Credentials stored at `~/.config/skillfish/credentials.json`
- **Secure permissions:** File created with `0o600`, directory with `0o700`
- **Token resolution order:** `SKILLFISH_TOKEN` env var → stored credentials file
- **API validation:** Tokens validated against `https://skill.fish/api/v1/me` before storing
- **Full CLI support:** All commands support `--json` flag for automation

## Files Changed

| File | Description |
|------|-------------|
| `src/lib/auth.ts` | Token storage, retrieval, and validation |
| `src/commands/login.ts` | Login command |
| `src/commands/logout.ts` | Logout command |
| `src/commands/whoami.ts` | Whoami command |
| `src/utils.ts` | JSON output types |
| `src/index.ts` | Command registration |
| `src/__tests__/auth.test.ts` | Unit tests |

## Test Plan

- [x] `npm run build` - TypeScript compiles
- [x] `npm run lint` - No lint errors
- [x] `npm test` - All 222 tests pass

**Manual testing:**
- [ ] `skillfish login` - Interactive flow works
- [ ] `skillfish login --token sk_user_xxx` - Direct token works
- [ ] `skillfish whoami` - Shows user info
- [ ] `skillfish whoami --json` - JSON output correct
- [ ] `skillfish logout` - Removes credentials
- [ ] `SKILLFISH_TOKEN` env var takes precedence

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/kieranklaassen/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)