### PR TITLE
Fix skill installation when manifest path is "."

### DIFF
--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -313,6 +313,33 @@ describe('installSkill', () => {
     // but the function should have called rmSync in the finally block
   });
 
+  it('installs root-level skill when path is "." (from manifest)', async () => {
+    // Regression test for GitHub issue #53: update fails when manifest stores path as "."
+    mockDownloadTemplate.mockImplementation(async (_source: string, options: { dir: string }) => {
+      mkdirSync(options.dir, { recursive: true });
+      writeFileSync(join(options.dir, 'SKILL.md'), '# Root Skill');
+      return { dir: options.dir, source: _source, url: 'https://github.com/owner/repo' };
+    });
+
+    const agents = [createMockAgent('Agent1', '.agent1/skills')];
+
+    const result = await installSkill('owner', 'repo', '.', 'test-skill', agents, {
+      force: true,
+      baseDir: tempDir,
+      branch: 'main',
+      sha: 'abc123',
+    });
+
+    expect(result.failed).toBe(false);
+    expect(result.installed).toHaveLength(1);
+
+    // Verify giget was called without the "." path (should be github:owner/repo#main, not github:owner/repo/.#main)
+    expect(mockDownloadTemplate).toHaveBeenCalledWith('github:owner/repo#main', expect.any(Object));
+
+    // Verify SKILL.md was copied
+    expect(existsSync(join(tempDir, '.agent1/skills', 'test-skill', 'SKILL.md'))).toBe(true);
+  });
+
   it('handles 404 errors gracefully', async () => {
     mockDownloadTemplate.mockRejectedValue(new Error('404 Not Found'));
 

--- a/src/lib/installer.ts
+++ b/src/lib/installer.ts
@@ -157,7 +157,7 @@ export async function installSkill(
   try {
     // Download skill using giget (tarball-based, works reliably on all repo sizes)
     // Build giget source: github:owner/repo[/subpath][#branch]
-    const downloadPath = skillPath === SKILL_FILENAME ? '' : skillPath;
+    const downloadPath = skillPath === SKILL_FILENAME || skillPath === '.' ? '' : skillPath;
     let gigetSource = downloadPath
       ? `github:${owner}/${repo}/${downloadPath}`
       : `github:${owner}/${repo}`;


### PR DESCRIPTION
## Summary

Fixed a regression where skill installation fails when the manifest stores the skill path as `"."` (root level). The issue occurred because the giget source URL was being constructed incorrectly, resulting in `github:owner/repo/.#branch` instead of `github:owner/repo#branch`.

## Related Issue

Fixes #53: update fails when manifest stores path as "."

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

- Modified `installSkill()` in `src/lib/installer.ts` to treat `"."` the same as `SKILL_FILENAME` when constructing the giget source URL
- Added regression test to verify root-level skill installation works correctly when path is `"."`

## Testing

Added a new test case `'installs root-level skill when path is "." (from manifest)'` that:
- Verifies the giget source URL is constructed without the path component
- Confirms the skill files are correctly installed to the agent's skill directory
- Ensures the installation result indicates success

All existing tests continue to pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass

https://claude.ai/code/session_015E7z3LGnsLkwdomntma9QF