### PR TITLE
Update OpenClaw agent configuration paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Works with 32 agents including:
 | Antigravity | `~/.gemini/antigravity/skills/` |
 | Droid | `~/.factory/skills/` |
 | Augment | `~/.augment/rules/` |
-| OpenClaw | `~/.moltbot/skills/` |
+| OpenClaw | `~/.openclaw/skills/` |
 | CodeBuddy | `~/.codebuddy/skills/` |
 | Command Code | `~/.commandcode/skills/` |
 | Crush | `~/.config/crush/skills/` |

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -129,8 +129,9 @@ export const AGENT_CONFIGS: readonly AgentConfig[] = [
   {
     name: 'OpenClaw',
     dir: 'skills',
-    homePaths: ['.moltbot'],
-    cwdPaths: ['skills'],
+    globalDir: '.openclaw/skills',
+    homePaths: ['.openclaw/openclaw.json', '.openclaw'],
+    cwdPaths: ['.openclaw'],
   },
   {
     name: 'CodeBuddy',


### PR DESCRIPTION
## Summary

Updates the OpenClaw agent configuration to use the correct directory structure and paths. Changes the home directory from `.moltbot` to `.openclaw` and adds a new `globalDir` configuration field pointing to `.openclaw/skills`.

## Related Issue

<!-- Link to issue if applicable -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New agent support (adds support for a new AI agent)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes

- Updated `AGENT_CONFIGS` for OpenClaw agent:
  - Added `globalDir: '.openclaw/skills'` field
  - Changed `homePaths` from `['.moltbot']` to `['.openclaw/openclaw.json', '.openclaw']`
  - Changed `cwdPaths` from `['skills']` to `['.openclaw']`
- Updated README.md to reflect the correct OpenClaw skills directory path from `~/.moltbot/skills/` to `~/.openclaw/skills/`

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Testing

Configuration changes are straightforward path updates. Existing agent configuration tests will validate the structure.

https://claude.ai/code/session_01XxoNEk17n5v2j756kSSrKZ