### PR TITLE
Fix Windsurf agent detection and skill paths

### DIFF
--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -35,9 +35,14 @@ export const AGENT_CONFIGS: readonly AgentConfig[] = [
   },
   {
     name: 'Windsurf',
-    dir: '.codeium/windsurf/skills',
-    homePaths: ['.codeium/windsurf/config.json', '.codeium/windsurf/argv.json'],
-    cwdPaths: ['.codeium/windsurf'],
+    dir: '.windsurf/skills',
+    globalDir: '.codeium/windsurf/skills',
+    homePaths: [
+      '.codeium/windsurf/config.json',
+      '.codeium/windsurf/argv.json',
+      '.codeium/windsurf',
+    ],
+    cwdPaths: ['.windsurf'],
   },
   {
     name: 'Codex',


### PR DESCRIPTION
## Summary

- **Fixed detection**: Windsurf wasn't being detected because `homePaths` only checked for two specific config files (`config.json`, `argv.json`) that don't exist in all installations. Added `.codeium/windsurf` directory-level fallback.
- **Fixed project-level skill path**: Changed `dir` from `.codeium/windsurf/skills` to `.windsurf/skills` to match Windsurf's current project-level directory structure.
- **Added `globalDir`**: Global installs still use `~/.codeium/windsurf/skills`, so added `globalDir` to differentiate from the project-level path.
- **Fixed `cwdPaths`**: Changed from `['.codeium/windsurf']` to `['.windsurf']` for project-level detection.

## Test plan

- [x] TypeScript typecheck passes
- [x] All 213 tests pass
- [ ] Install a skill with Windsurf installed globally — verify Windsurf is detected
- [ ] Install a skill to a project with `.windsurf/` directory — verify Windsurf is detected

https://claude.ai/code/session_01KH1tMne3k5hTJBU1NDShsg