### PR TITLE
Add GitHub token auth for private repository support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ npm run typecheck      # TypeScript type checking
 
 - `src/utils.ts` - Pure functions for path validation, frontmatter parsing, type guards for GitHub API responses
 - `src/telemetry.ts` - Anonymous install tracking (disabled with DO_NOT_TRACK=1 or CI=true)
+- `src/lib/auth.ts` - GitHub token resolution (`getGitHubToken()`, `hasGitHubToken()`). Reads `SKILLFISH_GITHUB_TOKEN` > `GITHUB_TOKEN` > `GH_TOKEN`, falls back to `gh auth token`. Token is cached per-process; call `resetGitHubTokenCache()` in tests.
 
 ### Key Patterns
 

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for GitHub authentication token resolution.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getGitHubToken, hasGitHubToken, resetGitHubTokenCache } from '../lib/auth.js';
+
+// Mock child_process so we don't shell out to `gh` in tests
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+const mockExecFileSync = vi.mocked(execFileSync);
+
+describe('getGitHubToken', () => {
+  beforeEach(() => {
+    resetGitHubTokenCache();
+    process.env.SKILLFISH_GITHUB_TOKEN = '';
+    process.env.GITHUB_TOKEN = '';
+    process.env.GH_TOKEN = '';
+    mockExecFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.SKILLFISH_GITHUB_TOKEN = '';
+    process.env.GITHUB_TOKEN = '';
+    process.env.GH_TOKEN = '';
+  });
+
+  it('returns undefined when no token is available', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(getGitHubToken()).toBeUndefined();
+  });
+
+  it('reads SKILLFISH_GITHUB_TOKEN first', () => {
+    process.env.SKILLFISH_GITHUB_TOKEN = 'skillfish-tok';
+    process.env.GITHUB_TOKEN = 'github-tok';
+    process.env.GH_TOKEN = 'gh-tok';
+    expect(getGitHubToken()).toBe('skillfish-tok');
+  });
+
+  it('falls back to GITHUB_TOKEN when SKILLFISH_GITHUB_TOKEN is unset', () => {
+    process.env.GITHUB_TOKEN = 'github-tok';
+    process.env.GH_TOKEN = 'gh-tok';
+    expect(getGitHubToken()).toBe('github-tok');
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is unset', () => {
+    process.env.GH_TOKEN = 'gh-tok';
+    expect(getGitHubToken()).toBe('gh-tok');
+  });
+
+  it('treats empty string env vars as unset', () => {
+    process.env.GITHUB_TOKEN = '   ';
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(getGitHubToken()).toBeUndefined();
+  });
+
+  it('falls back to gh auth token when no env vars are set', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('gh-cli-token\n'));
+    expect(getGitHubToken()).toBe('gh-cli-token');
+  });
+
+  it('returns undefined when gh auth token returns empty string', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('  \n'));
+    expect(getGitHubToken()).toBeUndefined();
+  });
+
+  it('returns undefined when gh is not installed', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(getGitHubToken()).toBeUndefined();
+  });
+
+  it('caches the resolved token across calls', () => {
+    process.env.GITHUB_TOKEN = 'cached-tok';
+    getGitHubToken();
+    process.env.GITHUB_TOKEN = '';
+    // Still returns the cached value
+    expect(getGitHubToken()).toBe('cached-tok');
+  });
+
+  it('resetGitHubTokenCache clears the cache', () => {
+    process.env.GITHUB_TOKEN = 'first-tok';
+    getGitHubToken();
+    resetGitHubTokenCache();
+    process.env.GITHUB_TOKEN = '';
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(getGitHubToken()).toBeUndefined();
+  });
+});
+
+describe('hasGitHubToken', () => {
+  beforeEach(() => {
+    resetGitHubTokenCache();
+    process.env.GITHUB_TOKEN = '';
+    mockExecFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.GITHUB_TOKEN = '';
+  });
+
+  it('returns true when a token is present', () => {
+    process.env.GITHUB_TOKEN = 'some-token';
+    expect(hasGitHubToken()).toBe(true);
+  });
+
+  it('returns false when no token is available', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(hasGitHubToken()).toBe(false);
+  });
+});

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -29,9 +29,22 @@ vi.mock('../utils.js', async (importOriginal) => {
   };
 });
 
+// Mock auth module so tests control token availability
+vi.mock('../lib/auth.js', () => ({
+  getGitHubToken: vi.fn(),
+  hasGitHubToken: vi.fn(),
+  resetGitHubTokenCache: vi.fn(),
+}));
+
+import { getGitHubToken, hasGitHubToken } from '../lib/auth.js';
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockHasGitHubToken = vi.mocked(hasGitHubToken);
+
 describe('fetchWithRetry', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
   });
 
   it('returns response on successful fetch', async () => {
@@ -105,6 +118,8 @@ describe('fetchWithRetry', () => {
 describe('findAllSkillMdFiles', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -237,6 +252,8 @@ describe('findAllSkillMdFiles', () => {
 describe('fetchRecursiveTree', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
   });
 
   it('returns sha and tree on successful API response', async () => {
@@ -330,6 +347,76 @@ describe('fetchRecursiveTree', () => {
 
     expect(result.sha).toBe('f'.repeat(40));
     expect(result.tree).toEqual([]);
+  });
+});
+
+describe('GitHub auth header forwarding', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('sends Authorization header when token is available', async () => {
+    mockGetGitHubToken.mockReturnValue('my-secret-token');
+    mockHasGitHubToken.mockReturnValue(true);
+
+    const repoResponse = { default_branch: 'main' };
+    const treeResponse = {
+      sha: 'a'.repeat(40),
+      tree: [{ path: 'SKILL.md', type: 'blob' }],
+    };
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify(repoResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(treeResponse), { status: 200 }));
+
+    await findAllSkillMdFiles('owner', 'repo');
+
+    const firstCall = mockFetch.mock.calls[0];
+    const requestInit = firstCall[1] as RequestInit;
+    expect((requestInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer my-secret-token',
+    );
+  });
+
+  it('does not send Authorization header when no token is available', async () => {
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
+
+    const repoResponse = { default_branch: 'main' };
+    const treeResponse = {
+      sha: 'a'.repeat(40),
+      tree: [{ path: 'SKILL.md', type: 'blob' }],
+    };
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify(repoResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(treeResponse), { status: 200 }));
+
+    await findAllSkillMdFiles('owner', 'repo');
+
+    const firstCall = mockFetch.mock.calls[0];
+    const requestInit = firstCall[1] as RequestInit;
+    expect((requestInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('includes GITHUB_TOKEN hint in RepoNotFoundError when no token is set', async () => {
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
+    mockFetch.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    await expect(fetchRecursiveTree('owner', 'repo', 'main')).rejects.toThrow(
+      /GITHUB_TOKEN if this is a private repository/,
+    );
+  });
+
+  it('does not include GITHUB_TOKEN hint when a token is already set', async () => {
+    mockGetGitHubToken.mockReturnValue('tok');
+    mockHasGitHubToken.mockReturnValue(true);
+    mockFetch.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    const err = await fetchRecursiveTree('owner', 'repo', 'main').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RepoNotFoundError);
+    const message = (err as RepoNotFoundError).message;
+    expect(message).not.toContain('GITHUB_TOKEN');
+    expect(message).toMatch(/Check the owner\/repo name\.$/);
   });
 });
 

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   findAllSkillMdFiles,
   fetchRecursiveTree,
+  fetchDefaultBranch,
   getSkillSha,
   RateLimitError,
   RepoNotFoundError,
@@ -417,6 +418,27 @@ describe('GitHub auth header forwarding', () => {
     const message = (err as RepoNotFoundError).message;
     expect(message).not.toContain('GITHUB_TOKEN');
     expect(message).toMatch(/Check the owner\/repo name\.$/);
+  });
+
+  it('includes GITHUB_TOKEN hint in fetchDefaultBranch 404 when no token is set', async () => {
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
+    mockFetch.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    await expect(fetchDefaultBranch('owner', 'repo')).rejects.toThrow(
+      /GITHUB_TOKEN if this is a private repository/,
+    );
+  });
+
+  it('does not include GITHUB_TOKEN hint in fetchDefaultBranch 404 when token is set', async () => {
+    mockGetGitHubToken.mockReturnValue('tok');
+    mockHasGitHubToken.mockReturnValue(true);
+    mockFetch.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    const err = await fetchDefaultBranch('owner', 'repo').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RepoNotFoundError);
+    expect((err as RepoNotFoundError).message).not.toContain('GITHUB_TOKEN');
+    expect((err as RepoNotFoundError).message).toMatch(/Check the owner\/repo name\.$/);
   });
 });
 

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -168,6 +168,17 @@ vi.mock('giget', () => {
   };
 });
 
+// Mock auth module
+vi.mock('../lib/auth.js', () => ({
+  getGitHubToken: vi.fn(),
+  hasGitHubToken: vi.fn(),
+  resetGitHubTokenCache: vi.fn(),
+}));
+
+import { getGitHubToken, hasGitHubToken } from '../lib/auth.js';
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockHasGitHubToken = vi.mocked(hasGitHubToken);
+
 describe('installSkill', () => {
   let tempDir: string;
   let mockDownloadTemplate: ReturnType<typeof vi.fn>;
@@ -179,6 +190,10 @@ describe('installSkill', () => {
     const gigetModule = await import('giget');
     mockDownloadTemplate = gigetModule.downloadTemplate as ReturnType<typeof vi.fn>;
     mockDownloadTemplate.mockReset();
+
+    // Default: no token
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -352,5 +367,74 @@ describe('installSkill', () => {
 
     expect(result.failed).toBe(true);
     expect(result.failureReason).toContain('Repository or path not found');
+  });
+
+  it('includes GITHUB_TOKEN hint in 404 message when no token is set', async () => {
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
+    mockDownloadTemplate.mockRejectedValue(new Error('404 Not Found'));
+
+    const agents = [createMockAgent('Agent1', '.agent1/skills')];
+    const result = await installSkill('owner', 'repo', 'SKILL.md', 'test-skill', agents, {
+      force: false,
+      baseDir: tempDir,
+    });
+
+    expect(result.failureReason).toContain('set GITHUB_TOKEN if this is a private repository');
+  });
+
+  it('omits GITHUB_TOKEN hint in 404 message when a token is already set', async () => {
+    mockGetGitHubToken.mockReturnValue('my-token');
+    mockHasGitHubToken.mockReturnValue(true);
+    mockDownloadTemplate.mockRejectedValue(new Error('404 Not Found'));
+
+    const agents = [createMockAgent('Agent1', '.agent1/skills')];
+    const result = await installSkill('owner', 'repo', 'SKILL.md', 'test-skill', agents, {
+      force: false,
+      baseDir: tempDir,
+    });
+
+    expect(result.failureReason).toContain('Repository or path not found');
+    expect(result.failureReason).not.toContain('GITHUB_TOKEN');
+  });
+
+  it('passes auth token to downloadTemplate when token is available', async () => {
+    mockGetGitHubToken.mockReturnValue('secret-token');
+    mockHasGitHubToken.mockReturnValue(true);
+    mockDownloadTemplate.mockImplementation(async (_source: string, options: { dir: string }) => {
+      mkdirSync(options.dir, { recursive: true });
+      writeFileSync(join(options.dir, 'SKILL.md'), '# Skill');
+      return { dir: options.dir, source: _source, url: 'https://github.com/owner/repo' };
+    });
+
+    const agents = [createMockAgent('Agent1', '.agent1/skills')];
+    await installSkill('owner', 'repo', 'SKILL.md', 'test-skill', agents, {
+      force: false,
+      baseDir: tempDir,
+    });
+
+    expect(mockDownloadTemplate).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ auth: 'secret-token' }),
+    );
+  });
+
+  it('does not pass auth option to downloadTemplate when no token', async () => {
+    mockGetGitHubToken.mockReturnValue(undefined);
+    mockHasGitHubToken.mockReturnValue(false);
+    mockDownloadTemplate.mockImplementation(async (_source: string, options: { dir: string }) => {
+      mkdirSync(options.dir, { recursive: true });
+      writeFileSync(join(options.dir, 'SKILL.md'), '# Skill');
+      return { dir: options.dir, source: _source, url: 'https://github.com/owner/repo' };
+    });
+
+    const agents = [createMockAgent('Agent1', '.agent1/skills')];
+    await installSkill('owner', 'repo', 'SKILL.md', 'test-skill', agents, {
+      force: false,
+      baseDir: tempDir,
+    });
+
+    const callOptions = mockDownloadTemplate.mock.calls[0][1] as Record<string, unknown>;
+    expect(callOptions['auth']).toBeUndefined();
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,9 @@ let cachedToken: string | null | undefined = undefined;
  *   2. GITHUB_TOKEN
  *   3. GH_TOKEN
  *   4. `gh auth token` (if gh is on PATH and the user is logged in)
+ *
+ * Resolution happens once per process and the result is cached. Set env vars
+ * before the first call, or call `resetGitHubTokenCache()` to re-resolve.
  */
 export function getGitHubToken(): string | undefined {
   if (cachedToken !== undefined) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,58 @@
+/**
+ * GitHub authentication helpers for skillfish.
+ */
+
+import { execFileSync } from 'child_process';
+
+// Module-scoped cache: undefined = not yet resolved, null = resolved to no token
+let cachedToken: string | null | undefined = undefined;
+
+/**
+ * Resolve a GitHub token from the environment or the local `gh` CLI.
+ *
+ * Priority:
+ *   1. SKILLFISH_GITHUB_TOKEN
+ *   2. GITHUB_TOKEN
+ *   3. GH_TOKEN
+ *   4. `gh auth token` (if gh is on PATH and the user is logged in)
+ */
+export function getGitHubToken(): string | undefined {
+  if (cachedToken !== undefined) {
+    return cachedToken ?? undefined;
+  }
+
+  const fromEnv =
+    process.env.SKILLFISH_GITHUB_TOKEN?.trim() ||
+    process.env.GITHUB_TOKEN?.trim() ||
+    process.env.GH_TOKEN?.trim();
+
+  if (fromEnv) {
+    cachedToken = fromEnv;
+    return cachedToken;
+  }
+
+  // Fallback: ask the gh CLI for the active token (~50 ms, silent on failure)
+  try {
+    const raw = execFileSync('gh', ['auth', 'token'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    })
+      .toString()
+      .trim();
+    cachedToken = raw || null;
+  } catch {
+    cachedToken = null;
+  }
+
+  return cachedToken ?? undefined;
+}
+
+/** Returns true when a GitHub token is available. */
+export function hasGitHubToken(): boolean {
+  return getGitHubToken() !== undefined;
+}
+
+/** Reset the per-process token cache. Intended for use in tests only. */
+export function resetGitHubTokenCache(): void {
+  cachedToken = undefined;
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -4,6 +4,7 @@
 
 import { isGitTreeResponse, extractSkillPaths, type GitTreeItem } from '../utils.js';
 import { fetchWithRetry } from './http.js';
+import { getGitHubToken, hasGitHubToken } from './auth.js';
 
 export const SKILL_FILENAME = 'SKILL.md';
 
@@ -66,7 +67,10 @@ export class RepoNotFoundError extends Error {
     public owner: string,
     public repo: string,
   ) {
-    super(`Repository not found: ${owner}/${repo}. Check the owner/repo name.`);
+    super(
+      `Repository not found: ${owner}/${repo}. Check the owner/repo name` +
+        (hasGitHubToken() ? '.' : ', or set GITHUB_TOKEN if this is a private repository.'),
+    );
     this.name = 'RepoNotFoundError';
   }
 }
@@ -92,6 +96,13 @@ export class GitHubApiError extends Error {
 }
 
 // === Helper Functions ===
+
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'User-Agent': 'skillfish' };
+  const token = getGitHubToken();
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
 
 /**
  * Check if a response indicates rate limiting and throw RateLimitError if so.
@@ -143,7 +154,7 @@ function wrapApiError(err: unknown): never {
  * @throws {NetworkError} On network errors
  */
 export async function fetchDefaultBranch(owner: string, repo: string): Promise<string> {
-  const headers: Record<string, string> = { 'User-Agent': 'skillfish' };
+  const headers = githubHeaders();
   const url = `https://api.github.com/repos/${owner}/${repo}`;
 
   try {
@@ -180,7 +191,7 @@ export async function fetchSkillMdContent(
   path: string,
   branch: string,
 ): Promise<string | null> {
-  const headers = { 'User-Agent': 'skillfish' };
+  const headers = githubHeaders();
   const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
 
   try {
@@ -202,7 +213,7 @@ export async function fetchSkillMdContent(
  * @throws {GitHubApiError} When the API response format is unexpected
  */
 export async function fetchTreeSha(owner: string, repo: string, branch: string): Promise<string> {
-  const headers: Record<string, string> = { 'User-Agent': 'skillfish' };
+  const headers = githubHeaders();
   const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`;
 
   try {
@@ -243,7 +254,7 @@ export async function fetchRecursiveTree(
   repo: string,
   branch: string,
 ): Promise<{ sha: string; tree: GitTreeItem[] }> {
-  const headers: Record<string, string> = { 'User-Agent': 'skillfish' };
+  const headers = githubHeaders();
   const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
 
   try {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -67,10 +67,8 @@ export class RepoNotFoundError extends Error {
     public owner: string,
     public repo: string,
   ) {
-    super(
-      `Repository not found: ${owner}/${repo}. Check the owner/repo name` +
-        (hasGitHubToken() ? '.' : ', or set GITHUB_TOKEN if this is a private repository.'),
-    );
+    const hint = hasGitHubToken() ? '' : ', or set GITHUB_TOKEN if this is a private repository';
+    super(`Repository not found: ${owner}/${repo}. Check the owner/repo name${hint}.`);
     this.name = 'RepoNotFoundError';
   }
 }

--- a/src/lib/installer.ts
+++ b/src/lib/installer.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { downloadTemplate } from 'giget';
 import { getAgentSkillDir, type Agent } from './agents.js';
+import { getGitHubToken, hasGitHubToken } from './auth.js';
 import { SKILL_FILENAME } from './github.js';
 import {
   writeManifest,
@@ -171,9 +172,11 @@ export async function installSkill(
       gigetSource = `${gigetSource}#${branch}`;
     }
 
+    const githubToken = getGitHubToken();
     await downloadTemplate(gigetSource, {
       dir: tmpDir,
       forceClean: true,
+      ...(githubToken ? { auth: githubToken } : {}),
     });
 
     // Validate download
@@ -307,7 +310,8 @@ export async function installSkill(
       const errMsg = err instanceof Error ? err.message : String(err);
       // Provide more helpful error messages for common failures
       if (errMsg.includes('404') || errMsg.includes('Not Found')) {
-        result.failureReason = `Repository or path not found: ${owner}/${repo}${skillPath !== SKILL_FILENAME ? `/${skillPath}` : ''}`;
+        const hint = hasGitHubToken() ? '' : ' (set GITHUB_TOKEN if this is a private repository)';
+        result.failureReason = `Repository or path not found: ${owner}/${repo}${skillPath !== SKILL_FILENAME ? `/${skillPath}` : ''}${hint}`;
       } else {
         result.failureReason = errMsg;
       }


### PR DESCRIPTION
## Problem

`skillfish add owner/repo` fails with *"Repository not found"* for private GitHub repositories, even when the user has valid credentials available locally (via `gh auth login` or `GITHUB_TOKEN` in the environment). The root cause is that all GitHub API calls and the `giget` tarball download run with no `Authorization` header, so GitHub returns 404 for any repo the anonymous client cannot see.

## Solution

- New `src/lib/auth.ts` module that resolves a token from (in priority order):
  1. `SKILLFISH_GITHUB_TOKEN` — skillfish-specific override
  2. `GITHUB_TOKEN` — standard
  3. `GH_TOKEN` — gh CLI standard
  4. `gh auth token` — silent fallback if `gh` is on PATH and user is logged in
  - Token is cached per-process; `resetGitHubTokenCache()` exposed for tests
- All four GitHub API call sites in `github.ts` now forward `Authorization: Bearer <token>` when a token is available
- `giget`'s native `auth` option is passed to `downloadTemplate` in `installer.ts`
- `RepoNotFoundError` and the installer 404 message both append a hint to set `GITHUB_TOKEN` when no token is configured

## Changes

- `src/lib/auth.ts` *(new)* — token resolution module
- `src/lib/github.ts` — `githubHeaders()` helper; auth-aware `RepoNotFoundError` message
- `src/lib/installer.ts` — passes `auth` to `downloadTemplate`; improved 404 message
- `src/__tests__/auth.test.ts` *(new)* — 12 tests covering token precedence and caching
- `src/__tests__/github.test.ts` — auth header forwarding tests; 404 hint tests
- `src/__tests__/installer.test.ts` — `auth` option assertion; 404 hint tests

## Test plan

- [ ] All 233 existing + new tests pass (`npm test`)
- [ ] `npm run typecheck` and `npm run lint` are clean
- [ ] Manual: `GITHUB_TOKEN=$(gh auth token) skillfish add <private-owner>/<private-repo> --yes` succeeds
- [ ] Manual: no tokens set → fails with hint `"set GITHUB_TOKEN if this is a private repository"`
- [ ] Manual: public repo with no token set → behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)