### PR TITLE
Add Kimi CLI agent support (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Skills can be pinned to a specific ref (tag, branch, or commit) using `@ref` syn
 
 ## Supported Agents
 
-Works with 32 agents including:
+Works with 33 agents including:
 
-**Claude Code** · **Cursor** · **Windsurf** · **Codex** · **GitHub Copilot** · **Gemini CLI** · **OpenCode** · **Goose** · **Amp** · **Roo Code** · **Kiro CLI** · **Kilo Code** · **Trae** · **Cline** · **Antigravity** · **Droid** · **Augment** · **OpenClaw** · **CodeBuddy** · **Command Code** · **Crush** · **Kode** · **Mistral Vibe** · **Mux** · **OpenClaude IDE** · **OpenHands** · **Qoder** · **Qwen Code** · **Replit** · **Trae CN** · **Neovate** · **AdaL**
+**Claude Code** · **Cursor** · **Windsurf** · **Codex** · **GitHub Copilot** · **Gemini CLI** · **OpenCode** · **Goose** · **Amp** · **Roo Code** · **Kiro CLI** · **Kimi CLI** · **Kilo Code** · **Trae** · **Cline** · **Antigravity** · **Droid** · **Augment** · **OpenClaw** · **CodeBuddy** · **Command Code** · **Crush** · **Kode** · **Mistral Vibe** · **Mux** · **OpenClaude IDE** · **OpenHands** · **Qoder** · **Qwen Code** · **Replit** · **Trae CN** · **Neovate** · **AdaL**
 
 <details>
 <summary>All supported agents</summary>
@@ -144,6 +144,7 @@ Works with 32 agents including:
 | Amp | `~/.agents/skills/` |
 | Roo Code | `~/.roo/skills/` |
 | Kiro CLI | `~/.kiro/skills/` |
+| Kimi CLI | `~/.kimi/skills/` |
 | Kilo Code | `~/.kilocode/skills/` |
 | Trae | `~/.trae/skills/` |
 | Cline | `~/.cline/skills/` |

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -95,6 +95,12 @@ export const AGENT_CONFIGS: readonly AgentConfig[] = [
     cwdPaths: ['.kiro'],
   },
   {
+    name: 'Kimi CLI',
+    dir: '.kimi/skills',
+    homePaths: ['.kimi/kimi.json', '.kimi/config.toml', '.kimi'],
+    cwdPaths: ['.kimi'],
+  },
+  {
     name: 'Kilo Code',
     dir: '.kilocode/skills',
     homePaths: ['.kilocode'],


### PR DESCRIPTION
Detects ~/.kimi/{kimi.json,config.toml} or .kimi directory and installs
skills to .kimi/skills.