### PR TITLE
Capture skill path in skill_key + platform as text + skill_name rename

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -385,12 +385,16 @@ Examples:
 
         // Track successful installs (fire and forget — dispatched to detached worker)
         if (result.installed.length > 0) {
+          // skillPath is 'SKILL.md' for root skills, or a directory like
+          // 'skills/foo' for sub-skills in a monorepo.
+          const skillRepoPath = skillPath === SKILL_FILENAME ? undefined : skillPath;
           trackInstall(
             'add',
             owner,
             repo,
             skillName,
             result.installed.map((i) => i.agent),
+            skillRepoPath,
           );
         }
       }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -732,6 +732,7 @@ Examples:
           action.entry.repo,
           result.skillName,
           result.platform,
+          action.entry.path,
         );
         if (!jsonMode) {
           // Show which agents it was installed to if it's a partial install

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -107,7 +107,7 @@ export function trackInstall(
     // Fields for skill count increment
     owner,
     repo,
-    skillName,
+    skill_name: skillName,
     platform: platformText,
   });
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -78,6 +78,9 @@ export function trackCommand(command: string): void {
  * @param repo GitHub repository name
  * @param skillName Name of the skill being installed
  * @param platform Names of the agents the skill was installed to (e.g. ['Claude Code', 'Cursor'])
+ * @param path Path to the skill within the repo. Undefined for root-level
+ *   skills (whole repo is one skill). For monorepos, this disambiguates
+ *   sibling skills (e.g. 'skills/council' vs 'skills/marketing').
  */
 export function trackInstall(
   command: string,
@@ -85,16 +88,25 @@ export function trackInstall(
   repo: string,
   skillName: string,
   platform: readonly string[] = [],
+  path?: string,
 ): void {
   if (!command || !owner || !repo || !skillName) return;
+  // Canonical skill key: 'owner/repo' for root skills, 'owner/repo/path'
+  // for skills nested in a monorepo. Without the path component, every
+  // skill in a monorepo collapses to the same key.
+  const normalizedPath = path?.trim().replace(/^\/+|\/+$/g, '') || undefined;
+  const skillKey = normalizedPath ? `${owner}/${repo}/${normalizedPath}` : `${owner}/${repo}`;
   dispatch({
     event_type: 'install',
     command,
-    skill_key: `${owner}/${repo}`,
+    skill_key: skillKey,
     // Fields for skill count increment
     owner,
     repo,
     skillName,
+    // Path within the repo (undefined for root skills). Lets the backend
+    // slice by path without re-parsing skill_key.
+    path: normalizedPath ?? null,
     // De-duplicated agent names the skill landed on. Maps to the `platform`
     // column on the telemetry_events table. Empty array if unknown.
     platform: Array.from(new Set(platform)),

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -96,6 +96,10 @@ export function trackInstall(
   // skill in a monorepo collapses to the same key.
   const normalizedPath = path?.trim().replace(/^\/+|\/+$/g, '') || undefined;
   const skillKey = normalizedPath ? `${owner}/${repo}/${normalizedPath}` : `${owner}/${repo}`;
+  // platform is a single text column on telemetry_events. We send a
+  // comma-separated, de-duplicated list so one install stays one row
+  // (preserving download-count semantics). Agent names contain no commas.
+  const platformText = Array.from(new Set(platform)).join(', ');
   dispatch({
     event_type: 'install',
     command,
@@ -104,11 +108,6 @@ export function trackInstall(
     owner,
     repo,
     skillName,
-    // Path within the repo (undefined for root skills). Lets the backend
-    // slice by path without re-parsing skill_key.
-    path: normalizedPath ?? null,
-    // De-duplicated agent names the skill landed on. Maps to the `platform`
-    // column on the telemetry_events table. Empty array if unknown.
-    platform: Array.from(new Set(platform)),
+    platform: platformText,
   });
 }


### PR DESCRIPTION
## Summary

Three follow-up telemetry fixes after #65, driven by what's actually showing up (or not) in the `telemetry_events` table.

- **`skill_key` now includes the in-repo path** for monorepo skills. Previously every skill in a multi-skill repo collapsed to `owner/repo`. Now `team-attention/hoyeon/skills/council` is distinct from `team-attention/hoyeon/skills/marketing`. Root-level skills still use plain `owner/repo`.
- **`platform` is sent as a comma-separated text string**, not a JSON array, to match the `text` column on `telemetry_events`. One install still equals one row, so download-count semantics are unchanged. Agent names contain no commas, so this round-trips cleanly.
- **`skillName` field renamed to `skill_name`** for snake_case consistency with the rest of the payload (`event_type`, `skill_key`). The earlier rename in #36 missed this one.
- **Dropped the redundant `path` field** — it's already encoded inside `skill_key`.

## Wire payload after this change

```json
// command event (one per CLI invocation)
{"event_type": "command", "command": "add"}

// install event for a monorepo sub-skill
{
  "event_type": "install",
  "command": "add",
  "skill_key": "team-attention/hoyeon/skills/council",
  "owner": "team-attention",
  "repo": "hoyeon",
  "skill_name": "council",
  "platform": "Claude Code, Cursor"
}

// install event for a root-level skill
{
  "event_type": "install",
  "command": "add",
  "skill_key": "testany-io/testany-agent-skills",
  "owner": "testany-io",
  "repo": "testany-agent-skills",
  "skill_name": "testany-agent-skills",
  "platform": "Claude Code"
}
```

## Backend schema this expects

`telemetry_events` columns (all snake_case, all nullable except `event_type`):

| Column | Type | Notes |
|---|---|---|
| `event_type` | `text` | `'command'` or `'install'` — required |
| `command` | `text` | always set |
| `skill_key` | `text` | install events only |
| `owner` | `text` | install events only |
| `repo` | `text` | install events only |
| `skill_name` | `text` | install events only — **needs to be added** |
| `platform` | `text` | install events only — comma-separated agent names |

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run build` clean
- [x] `npm test` — 235/235 pass
- [x] End-to-end wire capture against a local fake `telemetry` endpoint:
  - `command` event arrives as `{event_type, command}`
  - install event for `team-attention/hoyeon` with path `skills/council` produces `skill_key=team-attention/hoyeon/skills/council`, `skill_name=council`, `platform="Claude Code, Cursor"`
  - install event for a root skill produces `skill_key=owner/repo` (no path), `skill_name=repo`
  - Multi-agent install: `platform` is `"Claude Code, Cursor"`; single-agent: `"Claude Code"`; empty: `""`
  - Slash normalization: `/sub/path/` → `sub/path` in `skill_key`

https://claude.ai/code/session_01NNWdGxePTFy2h67N4bFjNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWdGxePTFy2h67N4bFjNy)_