### PR TITLE
fix(submit): report failure when registry rejects submission

### DIFF
--- a/src/__tests__/submit.test.ts
+++ b/src/__tests__/submit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the `skillfish submit` command.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { invokeCli } from './invoke-cli.js';
+
+describe('submit command', () => {
+  it('shows help with --help', () => {
+    const { stdout, exitCode } = invokeCli(['submit', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Submit a repository to the skill registry');
+  });
+
+  it('requires a repository argument', () => {
+    const { exitCode, stderr } = invokeCli(['submit']);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("required argument 'repo'");
+  });
+
+  it('rejects invalid repo format (single part)', () => {
+    const { exitCode, stderr } = invokeCli(['submit', 'invalid']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Invalid format');
+  });
+
+  it('rejects invalid characters in owner/repo', () => {
+    const { exitCode, stderr } = invokeCli(['submit', 'owner;evil/repo']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Invalid repository format');
+  });
+
+  it('outputs valid JSON with --json flag for invalid format', () => {
+    const { stdout, exitCode } = invokeCli(['--json', 'submit', 'invalid']);
+    expect(exitCode).toBe(2);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    const json = JSON.parse(stdout);
+    expect(json.success).toBe(false);
+    expect(json.exit_code).toBe(2);
+    expect(json.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-github.com URLs', () => {
+    // URL must contain 'github.com' to trigger URL parsing path; hostname check catches spoofs
+    const { exitCode, stderr } = invokeCli(['submit', 'https://github.com.evil.com/owner/repo']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Only github.com URLs');
+  });
+
+  it('outputs success:false and non-zero exit_code when --json and registry fails', () => {
+    // Use a repo that does not exist on GitHub so discovery fails before registry call,
+    // confirming the command reports failure correctly via JSON output.
+    const { stdout, exitCode } = invokeCli([
+      '--json',
+      'submit',
+      'skillfish-test-nonexistent-owner-xyz/nonexistent-repo-xyz',
+      '--yes',
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    const json = JSON.parse(stdout);
+    expect(json.success).toBe(false);
+    expect(json.exit_code).not.toBe(0);
+  }, 30_000);
+});

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -229,6 +229,7 @@ Examples:
           skill: repo,
           reason: submission?.error ?? 'Unknown error',
         });
+        jsonOutput.success = false;
       }
     } catch (err) {
       if (spinner) {
@@ -249,7 +250,9 @@ Examples:
 
     // Summary
     if (jsonMode) {
-      outputJsonAndExit(EXIT_CODES.SUCCESS);
+      outputJsonAndExit(
+        jsonOutput.failed.length > 0 ? EXIT_CODES.NETWORK_ERROR : EXIT_CODES.SUCCESS,
+      );
     }
 
     if (jsonOutput.submitted.length > 0) {
@@ -257,11 +260,12 @@ Examples:
       p.outro(
         pc.green(`Submitted! ${skillCount} skill${skillCount === 1 ? '' : 's'} will be reviewed.`),
       );
+      process.exit(EXIT_CODES.SUCCESS);
     } else {
       const errorReason = jsonOutput.failed[0]?.reason ?? 'Submission failed';
       p.outro(pc.red(errorReason));
+      process.exit(EXIT_CODES.NETWORK_ERROR);
     }
-    process.exit(EXIT_CODES.SUCCESS);
   });
 
 // === Helper Functions ===


### PR DESCRIPTION
## Summary

Fixes #68

When `submitSkillsToRegistry` returns failed submissions (e.g. HTTP 429 non-JSON from the registry), the JSON output incorrectly reported `success: true` with `exit_code: 0`. Automation relying on these signals would silently miss failed submissions.

**Root cause** (`src/commands/submit.ts`): the `else` branch that pushes to `failed[]` never set `jsonOutput.success = false`, and the JSON exit always called `outputJsonAndExit(EXIT_CODES.SUCCESS)` unconditionally.

**Changes:**
- Set `jsonOutput.success = false` when any submission lands in `failed[]`
- Exit with `EXIT_CODES.NETWORK_ERROR` (3) in both JSON and TTY modes when the registry rejects the submission
- Add `src/__tests__/submit.test.ts` covering argument validation and the JSON failure contract

**Before:**
```json
{ "success": true, "failed": [{ "skill": "...", "reason": "Registry returned non-JSON response (HTTP 429): ..." }], "exit_code": 0 }
```

**After:**
```json
{ "success": false, "failed": [{ "skill": "...", "reason": "Registry returned non-JSON response (HTTP 429): ..." }], "exit_code": 3 }
```

## Test plan

- [x] All 7 new `submit.test.ts` tests pass
- [x] `success: false` + non-zero `exit_code` for invalid args in JSON mode
- [x] Non-zero exit for non-existent repo (covers failure path before registry)
- [x] Existing test suite unaffected

https://claude.ai/code/session_01CogjFAAGo379Vv3dPLPkzP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CogjFAAGo379Vv3dPLPkzP)_