### PR TITLE
fix: surface clear rate-limit error for registry 429 responses

### DIFF
--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the registry API client.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { submitSkillsToRegistry, searchSkillsInRegistry } from '../lib/registry.js';
+
+// Helper to build a mock Response
+function mockResponse(
+  status: number,
+  body: string,
+  headers: Record<string, string> = {},
+): Response {
+  const headersObj = new Headers({ 'content-type': 'text/plain', ...headers });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: headersObj,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  } as unknown as Response;
+}
+
+describe('submitSkillsToRegistry', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a clear rate-limit error on 429 without retry-after', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(429, 'Too Many Requests'));
+
+    const result = await submitSkillsToRegistry([
+      {
+        url: 'https://github.com/owner/repo',
+        owner: 'owner',
+        repo: 'repo',
+        skill: 'repo',
+        path: '',
+      },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.submitted[0].error).toMatch(/rate limit exceeded/i);
+    expect(result.submitted[0].error).toContain('429');
+    expect(result.submitted[0].error).not.toContain('non-JSON');
+  });
+
+  it('includes retry-after hint when header is present on 429', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(429, 'Too Many Requests', { 'retry-after': '60' }),
+    );
+
+    const result = await submitSkillsToRegistry([
+      {
+        url: 'https://github.com/owner/repo',
+        owner: 'owner',
+        repo: 'repo',
+        skill: 'repo',
+        path: '',
+      },
+    ]);
+
+    expect(result.submitted[0].error).toContain('60 seconds');
+  });
+});
+
+describe('searchSkillsInRegistry', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a clear rate-limit error on 429 without retry-after', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(429, 'Too Many Requests'));
+
+    const result = await searchSkillsInRegistry('some-query');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/rate limit exceeded/i);
+    expect(result.error).toContain('429');
+    expect(result.error).not.toContain('non-JSON');
+  });
+
+  it('includes retry-after hint when header is present on 429', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(429, 'Too Many Requests', { 'retry-after': '30' }),
+    );
+
+    const result = await searchSkillsInRegistry('some-query');
+
+    expect(result.error).toContain('30 seconds');
+  });
+});

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -85,6 +85,15 @@ export async function submitSkillsToRegistry(
         MAX_RETRIES,
       );
 
+      // Handle rate limiting before content-type check (429 body is often non-JSON)
+      if (res.status === 429) {
+        const retryAfter = res.headers.get('retry-after');
+        const hint = retryAfter
+          ? ` Try again in ${retryAfter} seconds.`
+          : ' Please try again later.';
+        throw new Error(`Registry rate limit exceeded (HTTP 429).${hint}`);
+      }
+
       // Validate Content-Type before parsing JSON
       const contentType = res.headers.get('content-type');
       if (!contentType?.includes('application/json')) {
@@ -216,6 +225,18 @@ export async function searchSkillsInRegistry(
       },
       MAX_RETRIES,
     );
+
+    // Handle rate limiting before content-type check (429 body is often non-JSON)
+    if (res.status === 429) {
+      const retryAfter = res.headers.get('retry-after');
+      const hint = retryAfter ? ` Try again in ${retryAfter} seconds.` : ' Please try again later.';
+      return {
+        success: false,
+        results: [],
+        totalCount: 0,
+        error: `Registry rate limit exceeded (HTTP 429).${hint}`,
+      };
+    }
 
     // Validate Content-Type before parsing JSON
     const contentType = res.headers.get('content-type');


### PR DESCRIPTION
## Summary

Fixes #71 — `skillfish submit` (and `skillfish search`) showed a confusing "Registry returned non-JSON response (HTTP 429)" message when the registry rate-limited the request. 

**Root cause**: The non-JSON content-type guard ran before any HTTP-status check. A 429 body is typically plain text / HTML, so it fell into the generic non-JSON branch instead of producing a useful rate-limit message.

**Fix**:
- Added an explicit `res.status === 429` check _before_ the content-type guard in both `submitSkillsToRegistry` and `searchSkillsInRegistry` in `src/lib/registry.ts`
- Returns "Registry rate limit exceeded (HTTP 429). Please try again later." (or "Try again in N seconds." when a `Retry-After` header is present)

## Test plan

- [x] New `src/__tests__/registry.test.ts` covers both functions: clear error on bare 429, and `Retry-After` seconds hint
- [x] All 246 existing tests still pass (`npm test`)
- [x] TypeScript clean (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYmsc1aJ2VicCXfjxTAyRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYmsc1aJ2VicCXfjxTAyRs)_