### PR TITLE
feat: add Hermes Agent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ Skills can be pinned to a specific ref (tag, branch, or commit) using `@ref` syn
 
 ## Supported Agents
 
-Works with 33 agents including:
+Works with 34 agents including:
 
-**Claude Code** · **Cursor** · **Windsurf** · **Codex** · **GitHub Copilot** · **Gemini CLI** · **OpenCode** · **Goose** · **Amp** · **Roo Code** · **Kiro CLI** · **Kimi CLI** · **Kilo Code** · **Trae** · **Cline** · **Antigravity** · **Droid** · **Augment** · **OpenClaw** · **CodeBuddy** · **Command Code** · **Crush** · **Kode** · **Mistral Vibe** · **Mux** · **OpenClaude IDE** · **OpenHands** · **Qoder** · **Qwen Code** · **Replit** · **Trae CN** · **Neovate** · **AdaL**
+**Hermes Agent** · **Claude Code** · **Cursor** · **Windsurf** · **Codex** · **GitHub Copilot** · **Gemini CLI** · **OpenCode** · **Goose** · **Amp** · **Roo Code** · **Kiro CLI** · **Kimi CLI** · **Kilo Code** · **Trae** · **Cline** · **Antigravity** · **Droid** · **Augment** · **OpenClaw** · **CodeBuddy** · **Command Code** · **Crush** · **Kode** · **Mistral Vibe** · **Mux** · **OpenClaude IDE** · **OpenHands** · **Qoder** · **Qwen Code** · **Replit** · **Trae CN** · **Neovate** · **AdaL**
 
 <details>
 <summary>All supported agents</summary>
 
 | Agent | Skills Directory |
 |-------|------------------|
+| Hermes Agent | `$HERMES_HOME/skills/` or `~/.hermes/skills/` |
 | Claude Code | `~/.claude/skills/` |
 | Cursor | `~/.cursor/skills/` |
 | Windsurf | `~/.codeium/windsurf/skills/` |

--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -52,6 +52,14 @@ describe('agents.ts', () => {
       }
     });
 
+    it('includes Hermes Agent', () => {
+      const hermes = AGENT_CONFIGS.find((c) => c.name === 'Hermes Agent');
+      expect(hermes).toBeDefined();
+      expect(hermes?.dir).toContain('skills');
+      expect(hermes?.homePaths).toContain(hermes?.dir.replace(/[/\\]skills$/, ''));
+      expect(hermes?.cwdPaths).toEqual([]);
+    });
+
     it('includes Claude Code agent', () => {
       const claude = AGENT_CONFIGS.find((c) => c.name === 'Claude Code');
       expect(claude).toBeDefined();

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -5,7 +5,7 @@
 
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, relative } from 'path';
 
 /**
  * Agent configuration - data-driven for easier maintenance.
@@ -19,7 +19,22 @@ export interface AgentConfig {
   readonly cwdPaths: readonly string[]; // Paths to check in ./
 }
 
+const HOME_DIR = homedir();
+const HERMES_HOME_REL =
+  process.env.HERMES_HOME && HOME_DIR ? relative(HOME_DIR, process.env.HERMES_HOME) : '.hermes';
+
 export const AGENT_CONFIGS: readonly AgentConfig[] = [
+  // === Hermes Agent ===
+  {
+    name: 'Hermes Agent',
+    dir: join(HERMES_HOME_REL, 'skills'),
+    homePaths: [
+      HERMES_HOME_REL,
+      join(HERMES_HOME_REL, 'config.yaml'),
+      join(HERMES_HOME_REL, 'hermes-agent'),
+    ],
+    cwdPaths: [],
+  },
   // === Primary Agents (widely used) ===
   {
     name: 'Claude Code',


### PR DESCRIPTION
## Summary
- add Hermes Agent to SkillFish agent detection
- install Hermes skills into `$HERMES_HOME/skills` when set, otherwise `~/.hermes/skills`
- document Hermes Agent in the supported agents table

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Note: `npm test -- src/__tests__/agents.test.ts` currently fails on Windows because existing tests assert POSIX-style paths while Node returns Windows path separators. The new Hermes test imports and typechecks successfully; CI on Linux should exercise the test suite normally.