### PR TITLE
fix(tests): invoke the CLI without npx so the suite runs on Windows

### DIFF
--- a/src/__tests__/invoke-cli.ts
+++ b/src/__tests__/invoke-cli.ts
@@ -24,8 +24,10 @@ export interface CliResult {
  */
 export function invokeCli(args: string[]): CliResult {
   try {
-    // Use execFileSync with array args to prevent shell injection
-    const stdout = execFileSync('npx', ['tsx', CLI_PATH, ...args], {
+    // Use execFileSync with array args to prevent shell injection.
+    // Run node directly with tsx as a loader rather than going through npx: on Windows
+    // npx is a .cmd shim, which execFileSync cannot launch without a shell.
+    const stdout = execFileSync(process.execPath, ['--import', 'tsx', CLI_PATH, ...args], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
## Summary

`npm test` fails on Windows before any assertion is reached, because the test helper
shells out through `npx`.

`src/__tests__/invoke-cli.ts` calls:

```ts
execFileSync('npx', ['tsx', CLI_PATH, ...args], …)
```

On Windows `npx` is `npx.cmd`, and `execFileSync` without a shell cannot launch it. Both
spellings fail:

| call | result |
| --- | --- |
| `execFileSync('npx', …)` | `ENOENT` — there is no extensionless `npx` |
| `execFileSync('npx.cmd', …)` | `EINVAL` — Node refuses to spawn `.cmd`/`.bat` without a shell since the CVE-2024-27980 mitigation (18.20.2 / 20.12.2 / 21.7.3) |

Either way the throw lands in the `catch`, which returns `exitCode: 1` with empty `stdout`
and `stderr`. Every test that asserts an exit code or reads output then fails against an
empty string, which is why the failures look like `expected 1 to be 2` and
`expected '' to contain …` rather than anything to do with spawning.

This is invisible in CI, which is `ubuntu-latest` on every job.

## Related Issue

None open — found while running the suite locally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] New agent support
- [ ] Breaking change
- [ ] Documentation update

## Testing

Windows 11, Node 22.14.0, npm 10.9.2, at `7b8c868`, with a `~/.claude/settings.json`
present so agent detection behaves as it does in CI.

| | before | after |
| --- | --- | --- |
| test files | 7 failed, 5 passed | **2 failed, 10 passed** |
| tests | 54 failed, 188 passed | **14 failed, 228 passed** |

`add`, `list`, `remove`, `submit` and `update` go fully green; `installer` drops from 10
failures to 2. `npm run build`, `npm run typecheck`, `npm run lint` and
`npm run format:check` all still exit 0.

**The 14 that remain are unrelated to this change and I have not touched them:**

- `installer.test.ts` (2) — `EPERM … symlink`. Creating symlinks on Windows needs elevated
  privileges or Developer Mode. That is the environment, not the code.
- `agents.test.ts` (12) — the assertions compare against POSIX literals such as
  `.claude/skills` and `/home/user/.claude`, while `path.join` returns backslashes on
  Windows. Real, but it is a separate change across a dozen assertions and I did not want
  to bundle an opinion about it into a one-line fix. Happy to open it separately if you
  want it.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines (`lint` and `format:check` clean)
- [ ] I have added tests that prove my fix/feature works — the fix is what lets 40 existing
      tests execute at all; a test asserting the helper can spawn would be testing the
      helper with the helper
- [ ] All new and existing tests pass — 228 of 242, with the 14 above pre-existing and
      unrelated. I would rather say so than tick this
- [x] The build succeeds (`npm run build`)
- [ ] I have updated documentation if needed — not applicable

## Note on the approach

Running `node --import tsx` instead of patching the `npx` name keeps `execFileSync` without
a shell, so the injection protection the original comment describes is unchanged. `--import`
needs Node 18.19+ or 20.6+; `actions/setup-node` with `node-version: 18` resolves to 18.20.x,
so all three entries in the CI matrix support it.
