### PR TITLE
docs: pin npx commands to skillfish@latest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: skillfish version
-      description: Run `npx skillfish --version`
+      description: Run `npx skillfish@latest --version`
       placeholder: '1.0.8'
     validations:
       required: true
@@ -51,7 +51,7 @@ body:
       label: Steps to reproduce
       description: Minimal steps to reproduce the bug
       placeholder: |
-        1. Run `npx skillfish add owner/repo`
+        1. Run `npx skillfish@latest add owner/repo`
         2. Select skill X
         3. See error
     validations:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ```bash
 # One-off skill installation
-npx skillfish add owner/repo
+npx skillfish@latest add owner/repo
 
 # For skill management (list, update, remove), install globally
 npm i -g skillfish


### PR DESCRIPTION
npx caches previously-run versions, so bare `npx skillfish` can silently run a stale release — e.g. missing the new `--agent` flag shipped in 1.0.39. This pins all documented npx commands to `@latest`:

- README Quick Start: `npx skillfish@latest add owner/repo`
- Bug report template: version check and repro steps

`src/index.ts` already used `npx skillfish@latest` in its update hint, so docs now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)