### PR TITLE
fix(agents): install Codex skills to .agents/skills

### DIFF
--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -65,6 +65,12 @@ describe('agents.ts', () => {
       expect(cursor).toBeDefined();
       expect(cursor?.dir).toBe('.cursor/skills');
     });
+
+    it('installs Codex skills to .agents/skills, the directory Codex actually scans', () => {
+      const codex = AGENT_CONFIGS.find((c) => c.name === 'Codex');
+      expect(codex).toBeDefined();
+      expect(codex?.dir).toBe('.agents/skills');
+    });
   });
 
   describe('detectAgent', () => {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -46,7 +46,7 @@ export const AGENT_CONFIGS: readonly AgentConfig[] = [
   },
   {
     name: 'Codex',
-    dir: '.codex/skills',
+    dir: '.agents/skills',
     homePaths: ['.codex/config.json', '.codex/settings.json', '.codex'],
     cwdPaths: ['.codex'],
   },


### PR DESCRIPTION
## Summary

`AGENT_CONFIGS` for Codex pointed skill installs at `.codex/skills`, but Codex only scans `.agents/skills` (repo scope, walked up to the repo root) and `$HOME/.agents/skills` (user scope) — `.codex` is config-only (`config.toml`). Skills installed with `skillfish add --agent Codex` landed in a directory Codex never reads: the install reported success, but the skill was invisible to Codex.

Changed the Codex entry's `dir` from `.codex/skills` to `.agents/skills`. `homePaths`/`cwdPaths` are untouched — they're still used purely for *detecting* that Codex is present (`.codex/config.json`, `.codex/settings.json`, `.codex`), which is unaffected by this change. No `globalDir` override is needed: `getAgentSkillDir` joins `dir` onto the home directory for global installs, so this alone resolves to `~/.agents/skills` for global scope and `<project>/.agents/skills` for project scope, matching both locations from the issue.

Not included: a migration/warning path for skills previously installed under the old `.codex/skills` location. That's optional follow-up scope beyond the root-cause fix and is worth tracking separately.

## Related Issue

Fixes #81

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New agent support (adds support for a new AI agent)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass (`npm test`)
- [x] The build succeeds (`npm run build`)
- [ ] I have updated documentation if needed

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build`, and `npm test` all pass (250/250 tests).
- Added a regression test in `src/__tests__/agents.test.ts` asserting the Codex config's `dir` is `.agents/skills`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfiX6FWtRZRRnPrfCNnij9)_